### PR TITLE
feat(inventory): supplier, warehouse and low-stock screens

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,11 @@ import CategoryWares from './pages/category/view_categories/CategoriesWithWare';
 import SizeList from './pages/size/view_sizes/SizeList';
 import Wares from './pages/ware/view_wares/Wares';
 import WareVariantForm from './pages/WareVariant';
+import SupplierList from './pages/supplier/view_suppliers/SupplierList';
+import AddSupplier from './pages/supplier/add_suppliers/AddSupplier';
+import WarehouseList from './pages/warehouse/view_warehouses/WarehouseList';
+import AddWarehouse from './pages/warehouse/add_warehouses/AddWarehouse';
+import LowStockPage from './pages/low_stock/LowStockPage';
 import ErrorBoundary from './pages/ErrorBoundary';
 import Login from './pages/login/login';
 import SignupPage from './pages/signup/SignupPage';
@@ -38,11 +43,16 @@ const App = () => {
             <Route path="/categories/:categoryId" element={<CategoryWares />} />
             <Route path="/sizes" element={<SizeList />} />
             <Route path="/wares" element={<Wares />} />
+            <Route path="/suppliers" element={<SupplierList />} />
+            <Route path="/warehouses" element={<WarehouseList />} />
+            <Route path="/low-stock" element={<LowStockPage />} />
             <Route element={<AdminRoute />}>
               <Route path="/add-ware" element={<ErrorBoundary><AddWare /></ErrorBoundary>} />
               <Route path="/brands/add" element={<AddBrand />} />
               <Route path="/categories/add" element={<AddCategory />} />
               <Route path="/sizes/add" element={<AddSize />} />
+              <Route path="/suppliers/add" element={<AddSupplier />} />
+              <Route path="/warehouses/add" element={<AddWarehouse />} />
               <Route path="/wares/:wareId/variants/new" element={<WareVariantForm />} />
               <Route path="/wares/:wareId/variants/:variantId/edit" element={<WareVariantForm />} />
             </Route>

--- a/src/components/ui/EntityCreatePage.tsx
+++ b/src/components/ui/EntityCreatePage.tsx
@@ -10,6 +10,7 @@ interface FieldConfig<T extends FormValues> {
   label: string;
   placeholder: string;
   type?: "text" | "number";
+  required?: boolean;
 }
 
 interface EntityCreatePageProps<T extends FormValues> {
@@ -72,7 +73,7 @@ function EntityCreatePage<T extends FormValues>({
                 value={values[field.name]}
                 placeholder={field.placeholder}
                 onChange={(event) => setValues({ ...values, [field.name]: event.target.value })}
-                required
+                required={field.required ?? true}
               />
             </label>
           ))}

--- a/src/config/navigation.ts
+++ b/src/config/navigation.ts
@@ -10,4 +10,7 @@ export const primaryNavigation: NavigationItem[] = [
   { to: "/brands", label: "Brands", shortLabel: "Brands" },
   { to: "/categories", label: "Categories", shortLabel: "Categories" },
   { to: "/sizes", label: "Sizes", shortLabel: "Sizes" },
+  { to: "/suppliers", label: "Suppliers", shortLabel: "Suppliers" },
+  { to: "/warehouses", label: "Warehouses", shortLabel: "Stores" },
+  { to: "/low-stock", label: "Low stock", shortLabel: "Low stock" },
 ];

--- a/src/pages/WareVariant.tsx
+++ b/src/pages/WareVariant.tsx
@@ -13,6 +13,7 @@ interface WareVariantFormData {
   sku: string;
   stock: number | "";
   price: number | "";
+  reorder_point: number | "";
 }
 
 const WareVariantForm = () => {
@@ -25,6 +26,7 @@ const WareVariantForm = () => {
     sku: "",
     stock: "",
     price: "",
+    reorder_point: "",
   });
   const [loading, setLoading] = useState(false);
 
@@ -42,10 +44,11 @@ const WareVariantForm = () => {
         .then((res) => {
           const v = res.data;
           setFormData({
-            size: v.size.id,
+            size: v.size.id ?? v.size,
             sku: v.sku || "",
             stock: v.stock || "",
             price: v.price || "",
+            reorder_point: v.reorder_point ?? "",
           });
         })
         .finally(() => setLoading(false));
@@ -74,6 +77,7 @@ const WareVariantForm = () => {
       size: Number(formData.size),
       stock: Number(formData.stock),
       price: Number(formData.price),
+      reorder_point: Number(formData.reorder_point) || 0,
     };
 
     try {
@@ -165,6 +169,22 @@ const WareVariantForm = () => {
             required
             min={0}
             step="0.01"
+            className="w-full border p-2 rounded"
+          />
+        </div>
+
+        <div>
+          <label htmlFor="reorder_point" className="block mb-1 font-medium">
+            Reorder point
+          </label>
+          <input
+            type="number"
+            id="reorder_point"
+            name="reorder_point"
+            value={formData.reorder_point}
+            onChange={handleChange}
+            min={0}
+            placeholder="Alert when stock falls to this level"
             className="w-full border p-2 rounded"
           />
         </div>

--- a/src/pages/low_stock/LowStockPage.tsx
+++ b/src/pages/low_stock/LowStockPage.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import api from "../../services/api";
+import PageHeader from "../../components/ui/PageHeader";
+
+interface SizeDetail {
+  size: string;
+  size_unit: string | null;
+}
+
+interface LowStockVariant {
+  id: number;
+  ware: number;
+  ware_name: string;
+  size_detail: SizeDetail;
+  stock: number;
+  reorder_point: number;
+}
+
+export default function LowStockPage() {
+  const [variants, setVariants] = useState<LowStockVariant[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    api
+      .get("/variants/low-stock/")
+      .then((res) => setVariants(res.data.results ?? res.data))
+      .catch(() => setError(true))
+      .finally(() => setLoading(false));
+  }, []);
+
+  return (
+    <div className="page-container">
+      <PageHeader
+        eyebrow="Alerts"
+        title="Low stock"
+        description="Variants at or below their reorder point. Receive new stock to clear them."
+      />
+
+      {loading && <p>Loading…</p>}
+      {error && <div className="notice notice--error">Could not load low-stock items.</div>}
+
+      {!loading && !error && variants.length === 0 && (
+        <div className="notice notice--success">Nothing to reorder — all stock is above its reorder point.</div>
+      )}
+
+      {variants.length > 0 && (
+        <div className="surface" style={{ overflowX: "auto" }}>
+          <table style={{ width: "100%", borderCollapse: "collapse" }}>
+            <thead>
+              <tr style={{ textAlign: "left" }}>
+                <th style={{ padding: "0.5rem" }}>Product</th>
+                <th style={{ padding: "0.5rem" }}>Size</th>
+                <th style={{ padding: "0.5rem" }}>In stock</th>
+                <th style={{ padding: "0.5rem" }}>Reorder point</th>
+                <th style={{ padding: "0.5rem" }} />
+              </tr>
+            </thead>
+            <tbody>
+              {variants.map((v) => (
+                <tr key={v.id} style={{ borderTop: "1px solid #eee" }}>
+                  <td style={{ padding: "0.5rem" }}>{v.ware_name}</td>
+                  <td style={{ padding: "0.5rem" }}>
+                    {v.size_detail?.size} {v.size_detail?.size_unit ?? ""}
+                  </td>
+                  <td style={{ padding: "0.5rem", color: "#b91c1c", fontWeight: 600 }}>{v.stock}</td>
+                  <td style={{ padding: "0.5rem" }}>{v.reorder_point}</td>
+                  <td style={{ padding: "0.5rem" }}>
+                    <Link className="inventory-list__open" to={`/wares/${v.ware}`}>
+                      View product →
+                    </Link>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/supplier/add_suppliers/AddSupplier.tsx
+++ b/src/pages/supplier/add_suppliers/AddSupplier.tsx
@@ -1,0 +1,30 @@
+import EntityCreatePage from "../../../components/ui/EntityCreatePage";
+
+const AddSupplier = () => (
+  <EntityCreatePage
+    eyebrow="Supply chain"
+    title="New supplier"
+    description="Record a vendor you receive stock from, including their typical lead time."
+    endpoint="/suppliers/"
+    initialValues={{
+      name: "",
+      contact_name: "",
+      phone_number: "",
+      email: "",
+      lead_time_days: "",
+      address: "",
+    }}
+    fields={[
+      { name: "name", label: "Supplier name", placeholder: "e.g. Dangote Distributors" },
+      { name: "contact_name", label: "Contact person", placeholder: "e.g. Musa Bello", required: false },
+      { name: "phone_number", label: "Phone", placeholder: "e.g. 0803 000 0000", required: false },
+      { name: "email", label: "Email", placeholder: "e.g. sales@vendor.com", required: false },
+      { name: "lead_time_days", label: "Lead time (days)", placeholder: "e.g. 3", type: "number", required: false },
+      { name: "address", label: "Address", placeholder: "Pickup / delivery address", required: false },
+    ]}
+    successMessage="Supplier saved and ready to use."
+    backTo="/suppliers"
+  />
+);
+
+export default AddSupplier;

--- a/src/pages/supplier/view_suppliers/SupplierList.tsx
+++ b/src/pages/supplier/view_suppliers/SupplierList.tsx
@@ -1,0 +1,20 @@
+import ListPage from "../../../shared/list_page/ListPage";
+
+type Supplier = {
+  id: number;
+  name: string;
+};
+
+export default function SupplierList() {
+  return (
+    <ListPage<Supplier>
+      title="Suppliers"
+      apiEndpoint="/suppliers/"
+      itemKey={(item) => item.id}
+      itemNameSelector={(item) => item.name}
+      navigateTo={() => "/suppliers"}
+      createPath="/suppliers/add"
+      createLabel="Add supplier"
+    />
+  );
+}

--- a/src/pages/warehouse/add_warehouses/AddWarehouse.tsx
+++ b/src/pages/warehouse/add_warehouses/AddWarehouse.tsx
@@ -1,0 +1,19 @@
+import EntityCreatePage from "../../../components/ui/EntityCreatePage";
+
+const AddWarehouse = () => (
+  <EntityCreatePage
+    eyebrow="Locations"
+    title="New warehouse"
+    description="Add a storage location so stock can be tracked per warehouse."
+    endpoint="/warehouses/"
+    initialValues={{ name: "", address: "" }}
+    fields={[
+      { name: "name", label: "Warehouse name", placeholder: "e.g. Main Store" },
+      { name: "address", label: "Address", placeholder: "Location / address", required: false },
+    ]}
+    successMessage="Warehouse saved and ready to use."
+    backTo="/warehouses"
+  />
+);
+
+export default AddWarehouse;

--- a/src/pages/warehouse/view_warehouses/WarehouseList.tsx
+++ b/src/pages/warehouse/view_warehouses/WarehouseList.tsx
@@ -1,0 +1,20 @@
+import ListPage from "../../../shared/list_page/ListPage";
+
+type Warehouse = {
+  id: number;
+  name: string;
+};
+
+export default function WarehouseList() {
+  return (
+    <ListPage<Warehouse>
+      title="Warehouses"
+      apiEndpoint="/warehouses/"
+      itemKey={(item) => item.id}
+      itemNameSelector={(item) => item.name}
+      navigateTo={() => "/warehouses"}
+      createPath="/warehouses/add"
+      createLabel="Add warehouse"
+    />
+  );
+}


### PR DESCRIPTION
Frontend Phase 1 gap-fill matching the new backend endpoints:

- Supplier and Warehouse list + create pages, wired into routing and the primary navigation.
- Low-stock page backed by GET /variants/low-stock/.
- Add a reorder point field to the variant form.
- Allow optional fields in EntityCreatePage.


Claude-Session: https://claude.ai/code/session_01RWNgRTeigt7cf31qX9ibvE