### PR TITLE
feat(sales): Sales & Invoicing UI + dual pricing forms

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,9 @@ import LowStockPage from './pages/low_stock/LowStockPage';
 import CustomerList from './pages/customer/view_customers/CustomerList';
 import CustomerForm from './pages/customer/CustomerForm';
 import CustomerDetail from './pages/customer/customer_details/CustomerDetail';
+import SalesList from './pages/sales/view_sales/SalesList';
+import CreateSale from './pages/sales/create_sale/CreateSale';
+import SaleDetail from './pages/sales/sale_details/SaleDetail';
 import ErrorBoundary from './pages/ErrorBoundary';
 import Login from './pages/login/login';
 import SignupPage from './pages/signup/SignupPage';
@@ -51,6 +54,9 @@ const App = () => {
             <Route path="/low-stock" element={<LowStockPage />} />
             <Route path="/customers" element={<CustomerList />} />
             <Route path="/customers/:customerId" element={<CustomerDetail />} />
+            <Route path="/sales" element={<SalesList />} />
+            <Route path="/sales/new" element={<CreateSale />} />
+            <Route path="/sales/:saleId" element={<SaleDetail />} />
             <Route element={<AdminRoute />}>
               <Route path="/add-ware" element={<ErrorBoundary><AddWare /></ErrorBoundary>} />
               <Route path="/brands/add" element={<AddBrand />} />

--- a/src/config/navigation.ts
+++ b/src/config/navigation.ts
@@ -6,6 +6,7 @@ export interface NavigationItem {
 
 export const primaryNavigation: NavigationItem[] = [
   { to: "/home", label: "Control desk", shortLabel: "Home" },
+  { to: "/sales", label: "Sales", shortLabel: "Sales" },
   { to: "/wares", label: "Products", shortLabel: "Products" },
   { to: "/brands", label: "Brands", shortLabel: "Brands" },
   { to: "/categories", label: "Categories", shortLabel: "Categories" },

--- a/src/index.css
+++ b/src/index.css
@@ -177,6 +177,59 @@ button, a { -webkit-tap-highlight-color: transparent; }
   .customer-detail-grid { grid-template-columns: 1fr; }
 }
 
+/* ---------- Sales ---------- */
+.sale-lines { display: grid; gap: 12px; margin-bottom: 16px; }
+.sale-line { display: grid; grid-template-columns: 1fr 80px 130px 130px auto; gap: 12px; align-items: end; }
+.sale-line__total { display: flex; flex-direction: column; gap: 4px; padding-bottom: 13px; }
+.sale-line__total strong { color: var(--leaf-950); }
+.sale-line__remove { align-self: end; margin-bottom: 5px; }
+.sale-line__warn { grid-column: 1 / -1; margin: -4px 0 0; color: var(--tomato-500); font-size: .78rem; font-weight: 700; }
+.sale-summary__inputs { grid-template-columns: repeat(3, 1fr); }
+.sale-totals { margin: 18px 0 0; display: grid; gap: 8px; max-width: 360px; margin-left: auto; }
+.sale-totals > div { display: flex; justify-content: space-between; gap: 24px; color: var(--ink-600); }
+.sale-totals dt, .sale-totals dd { margin: 0; }
+.sale-totals dd { font-weight: 700; color: var(--ink-900); }
+.sale-totals__grand { padding-top: 8px; border-top: 1px solid var(--glass-border); font-size: 1.1rem; }
+.sale-totals__grand dt, .sale-totals__grand dd { color: var(--leaf-950); font-weight: 800; }
+
+/* Branded invoice sheet */
+.invoice-sheet { padding: clamp(22px, 4vw, 40px); }
+.invoice-head { display: flex; justify-content: space-between; gap: 24px; flex-wrap: wrap; padding-bottom: 20px; border-bottom: 2px solid var(--leaf-800); }
+.invoice-brand { margin: 0; color: var(--leaf-950); font-family: "Arial Narrow", ui-sans-serif, system-ui, sans-serif; font-size: 2rem; letter-spacing: -.03em; }
+.invoice-brand__sub { margin: 4px 0 0; color: var(--ink-600); font-size: .85rem; }
+.invoice-meta { display: grid; gap: 6px; text-align: right; }
+.invoice-meta div { display: grid; }
+.invoice-meta span { color: var(--ink-600); font-size: .72rem; text-transform: uppercase; letter-spacing: .06em; }
+.invoice-meta strong { color: var(--leaf-950); }
+.invoice-billto { display: grid; gap: 3px; margin: 20px 0; }
+.invoice-billto strong { color: var(--leaf-950); font-size: 1.1rem; }
+.invoice-table { margin-bottom: 8px; }
+.invoice-totals { margin-top: 16px; }
+.invoice-notes { margin-top: 18px; color: var(--ink-600); font-style: italic; }
+.invoice-foot { margin-top: 24px; text-align: center; color: var(--leaf-650); font-weight: 700; }
+
+@media (max-width: 760px) {
+  .sale-line { grid-template-columns: 1fr 1fr; }
+  .sale-line__product { grid-column: 1 / -1; }
+  .sale-summary__inputs { grid-template-columns: 1fr; }
+  .sale-totals { max-width: none; }
+}
+
+/* Print: show only the invoice sheet */
+@media print {
+  .topbar, .app-footer, .app-shell__rail, .page-header__action, .no-print { display: none !important; }
+  html { background: #fff; }
+  body::before, body::after { display: none !important; }
+  .page-container { width: 100%; padding: 0; }
+  .page-header { margin-bottom: 12px; }
+  .invoice-sheet {
+    border: 0; box-shadow: none; background: #fff;
+    backdrop-filter: none; -webkit-backdrop-filter: none;
+  }
+  .invoice-sheet, .invoice-sheet * { color: #111 !important; }
+  .invoice-brand, .invoice-meta strong, .invoice-billto strong { color: #102d22 !important; }
+}
+
 /* ---------- Dashboard ---------- */
 .dashboard-grid { display: grid; grid-template-columns: repeat(12, 1fr); gap: 18px; }
 .dashboard-card {

--- a/src/pages/WareVariant.tsx
+++ b/src/pages/WareVariant.tsx
@@ -12,7 +12,8 @@ interface WareVariantFormData {
   size: number | "";
   sku: string;
   stock: number | "";
-  price: number | "";
+  retail_price: number | "";
+  wholesale_price: number | "";
   reorder_point: number | "";
 }
 
@@ -25,7 +26,8 @@ const WareVariantForm = () => {
     size: "",
     sku: "",
     stock: "",
-    price: "",
+    retail_price: "",
+    wholesale_price: "",
     reorder_point: "",
   });
   const [loading, setLoading] = useState(false);
@@ -47,7 +49,8 @@ const WareVariantForm = () => {
             size: v.size.id ?? v.size,
             sku: v.sku || "",
             stock: v.stock || "",
-            price: v.price || "",
+            retail_price: v.retail_price || "",
+            wholesale_price: v.wholesale_price || "",
             reorder_point: v.reorder_point ?? "",
           });
         })
@@ -76,7 +79,8 @@ const WareVariantForm = () => {
       ware: Number(wareId),
       size: Number(formData.size),
       stock: Number(formData.stock),
-      price: Number(formData.price),
+      retail_price: Number(formData.retail_price) || 0,
+      wholesale_price: Number(formData.wholesale_price) || 0,
       reorder_point: Number(formData.reorder_point) || 0,
     };
 
@@ -148,15 +152,28 @@ const WareVariantForm = () => {
           />
         </label>
 
-        <label className="field" htmlFor="price">
-          <span>Price</span>
+        <label className="field" htmlFor="retail_price">
+          <span>Retail price (₦)</span>
           <input
             type="number"
-            id="price"
-            name="price"
-            value={formData.price}
+            id="retail_price"
+            name="retail_price"
+            value={formData.retail_price}
             onChange={handleChange}
             required
+            min={0}
+            step="0.01"
+          />
+        </label>
+
+        <label className="field" htmlFor="wholesale_price">
+          <span>Wholesale price (₦)</span>
+          <input
+            type="number"
+            id="wholesale_price"
+            name="wholesale_price"
+            value={formData.wholesale_price}
+            onChange={handleChange}
             min={0}
             step="0.01"
           />

--- a/src/pages/sales/create_sale/CreateSale.tsx
+++ b/src/pages/sales/create_sale/CreateSale.tsx
@@ -1,0 +1,229 @@
+import { useEffect, useMemo, useState, type FormEvent } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { Plus, Trash2 } from "lucide-react";
+import api from "../../../services/api";
+import PageHeader from "../../../components/ui/PageHeader";
+import { formatNaira } from "../salesTypes";
+
+interface CustomerOption {
+  id: number;
+  name: string;
+  customer_type: "wholesale" | "retail";
+}
+
+interface VariantOption {
+  id: number;
+  ware_name: string;
+  size_detail: { size: string; size_unit: string | null };
+  retail_price: string;
+  wholesale_price: string;
+  stock: number;
+}
+
+interface LineItem {
+  variant: number | "";
+  quantity: number;
+  unit_price: string;
+}
+
+const emptyLine: LineItem = { variant: "", quantity: 1, unit_price: "" };
+
+const CreateSale = () => {
+  const navigate = useNavigate();
+  const [customers, setCustomers] = useState<CustomerOption[]>([]);
+  const [variants, setVariants] = useState<VariantOption[]>([]);
+  const [customerId, setCustomerId] = useState<number | "">("");
+  const [lines, setLines] = useState<LineItem[]>([{ ...emptyLine }]);
+  const [discount, setDiscount] = useState("0");
+  const [vatRate, setVatRate] = useState("7.5");
+  const [notes, setNotes] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    api.get("/customers/?page_size=1000").then((res) => setCustomers(res.data.results || res.data));
+    api.get("/variants/?page_size=1000").then((res) => setVariants(res.data.results || res.data));
+  }, []);
+
+  const variantMap = useMemo(() => new Map(variants.map((v) => [v.id, v])), [variants]);
+  const customerType = customers.find((c) => c.id === customerId)?.customer_type;
+
+  const priceFor = (variant: VariantOption) =>
+    customerType === "wholesale" && Number(variant.wholesale_price) > 0
+      ? variant.wholesale_price
+      : variant.retail_price;
+
+  const updateLine = (index: number, patch: Partial<LineItem>) => {
+    setLines((prev) => prev.map((line, i) => (i === index ? { ...line, ...patch } : line)));
+  };
+
+  const handleVariantChange = (index: number, variantId: number | "") => {
+    const v = variantId ? variantMap.get(Number(variantId)) : undefined;
+    updateLine(index, { variant: variantId, unit_price: v ? priceFor(v) : "" });
+  };
+
+  // Re-price lines when the customer (and therefore the price tier) changes.
+  const handleCustomerChange = (id: number | "") => {
+    setCustomerId(id);
+    const type = customers.find((c) => c.id === id)?.customer_type;
+    setLines((prev) =>
+      prev.map((line) => {
+        const v = line.variant ? variantMap.get(Number(line.variant)) : undefined;
+        if (!v) return line;
+        const price = type === "wholesale" && Number(v.wholesale_price) > 0 ? v.wholesale_price : v.retail_price;
+        return { ...line, unit_price: price };
+      })
+    );
+  };
+
+  const subtotal = lines.reduce((sum, l) => sum + Number(l.unit_price || 0) * Number(l.quantity || 0), 0);
+  const taxable = Math.max(subtotal - Number(discount || 0), 0);
+  const vatAmount = (taxable * Number(vatRate || 0)) / 100;
+  const total = taxable + vatAmount;
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    setError(null);
+    if (!customerId) return setError("Select a customer.");
+    const validLines = lines.filter((l) => l.variant && Number(l.quantity) > 0);
+    if (validLines.length === 0) return setError("Add at least one item.");
+
+    setSaving(true);
+    try {
+      const res = await api.post("/sales/", {
+        customer: customerId,
+        discount: discount || "0",
+        vat_rate: vatRate || "0",
+        notes: notes || null,
+        items: validLines.map((l) => ({
+          variant: Number(l.variant),
+          quantity: Number(l.quantity),
+          unit_price: l.unit_price,
+        })),
+      });
+      navigate(`/sales/${res.data.id}`);
+    } catch (err: unknown) {
+      const detail =
+        (err as { response?: { data?: unknown } })?.response?.data;
+      setError(
+        Array.isArray(detail) ? String(detail[0]) : typeof detail === "string" ? detail : "Could not create the sale. Check stock and details."
+      );
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="page-container">
+      <PageHeader
+        eyebrow="Invoices"
+        title="New sale"
+        description="Pick a customer, add items, and the price tier fills in automatically."
+      />
+
+      <form onSubmit={handleSubmit}>
+        {error && <div className="notice notice--error" role="alert">{error}</div>}
+
+        <div className="surface form-card" style={{ marginBottom: "18px" }}>
+          <div className="form-grid">
+            <label className="field">
+              <span>Customer</span>
+              <select value={customerId} onChange={(e) => handleCustomerChange(e.target.value ? Number(e.target.value) : "")} required>
+                <option value="">Select customer</option>
+                {customers.map((c) => (
+                  <option key={c.id} value={c.id}>
+                    {c.name} ({c.customer_type})
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+        </div>
+
+        {/* Line items */}
+        <div className="surface form-card" style={{ marginBottom: "18px" }}>
+          <h3 style={{ marginTop: 0, color: "var(--leaf-950)" }}>Items</h3>
+          <div className="sale-lines">
+            {lines.map((line, index) => {
+              const v = line.variant ? variantMap.get(Number(line.variant)) : undefined;
+              return (
+                <div className="sale-line" key={index}>
+                  <label className="field sale-line__product">
+                    <span>Product</span>
+                    <select value={line.variant} onChange={(e) => handleVariantChange(index, e.target.value ? Number(e.target.value) : "")}>
+                      <option value="">Select product</option>
+                      {variants.map((variant) => (
+                        <option key={variant.id} value={variant.id}>
+                          {variant.ware_name} ({variant.size_detail.size}{variant.size_detail.size_unit ?? ""}) · stock {variant.stock}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                  <label className="field sale-line__qty">
+                    <span>Qty</span>
+                    <input type="number" min={1} value={line.quantity} onChange={(e) => updateLine(index, { quantity: Number(e.target.value) })} />
+                  </label>
+                  <label className="field sale-line__price">
+                    <span>Unit price</span>
+                    <input type="number" min={0} step="0.01" value={line.unit_price} onChange={(e) => updateLine(index, { unit_price: e.target.value })} />
+                  </label>
+                  <div className="sale-line__total">
+                    <span className="customer-stat__label">Line</span>
+                    <strong>{formatNaira(Number(line.unit_price || 0) * Number(line.quantity || 0))}</strong>
+                  </div>
+                  <button
+                    type="button"
+                    className="button button--ghost button--small sale-line__remove"
+                    onClick={() => setLines((prev) => prev.filter((_, i) => i !== index))}
+                    disabled={lines.length === 1}
+                    aria-label="Remove item"
+                  >
+                    <Trash2 size={16} />
+                  </button>
+                  {v && line.quantity > v.stock && (
+                    <p className="sale-line__warn">Only {v.stock} in stock</p>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+          <button type="button" className="button button--ghost button--small" onClick={() => setLines((prev) => [...prev, { ...emptyLine }])}>
+            <Plus size={16} /> Add item
+          </button>
+        </div>
+
+        {/* Totals */}
+        <div className="surface form-card sale-summary">
+          <div className="form-grid sale-summary__inputs">
+            <label className="field">
+              <span>Discount (₦)</span>
+              <input type="number" min={0} step="0.01" value={discount} onChange={(e) => setDiscount(e.target.value)} />
+            </label>
+            <label className="field">
+              <span>VAT rate (%)</span>
+              <input type="number" min={0} step="0.1" value={vatRate} onChange={(e) => setVatRate(e.target.value)} />
+            </label>
+            <label className="field">
+              <span>Notes</span>
+              <input value={notes} onChange={(e) => setNotes(e.target.value)} placeholder="Optional" />
+            </label>
+          </div>
+          <dl className="sale-totals">
+            <div><dt>Subtotal</dt><dd>{formatNaira(subtotal)}</dd></div>
+            <div><dt>Discount</dt><dd>− {formatNaira(discount || 0)}</dd></div>
+            <div><dt>VAT ({vatRate || 0}%)</dt><dd>{formatNaira(vatAmount)}</dd></div>
+            <div className="sale-totals__grand"><dt>Total</dt><dd>{formatNaira(total)}</dd></div>
+          </dl>
+        </div>
+
+        <div className="form-actions">
+          <Link className="button button--ghost" to="/sales">Cancel</Link>
+          <button className="button button--primary" type="submit" disabled={saving}>
+            {saving ? "Saving…" : "Create sale"}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+};
+
+export default CreateSale;

--- a/src/pages/sales/sale_details/SaleDetail.tsx
+++ b/src/pages/sales/sale_details/SaleDetail.tsx
@@ -1,0 +1,195 @@
+import { useCallback, useEffect, useState, type FormEvent } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { Printer } from "lucide-react";
+import api from "../../../services/api";
+import PageHeader from "../../../components/ui/PageHeader";
+import { useUserRole } from "../../../hooks/useUserRole";
+import { type Sale, PAYMENT_METHODS, formatNaira, statusLabel } from "../salesTypes";
+
+const SaleDetail = () => {
+  const { saleId } = useParams<{ saleId: string }>();
+  const navigate = useNavigate();
+  const userRole = useUserRole();
+  const [sale, setSale] = useState<Sale | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const [amount, setAmount] = useState("");
+  const [method, setMethod] = useState("cash");
+  const [reference, setReference] = useState("");
+  const [payError, setPayError] = useState<string | null>(null);
+  const [savingPay, setSavingPay] = useState(false);
+
+  const fetchSale = useCallback(async () => {
+    try {
+      setLoading(true);
+      const res = await api.get<Sale>(`/sales/${saleId}/`);
+      setSale(res.data);
+    } catch (error) {
+      console.error("Failed to fetch sale:", error);
+    } finally {
+      setLoading(false);
+    }
+  }, [saleId]);
+
+  useEffect(() => {
+    fetchSale();
+  }, [fetchSale]);
+
+  const handleAddPayment = async (event: FormEvent) => {
+    event.preventDefault();
+    setPayError(null);
+    if (!amount || Number(amount) <= 0) return setPayError("Enter a valid amount.");
+    setSavingPay(true);
+    try {
+      await api.post("/payments/", { sale: Number(saleId), amount, method, reference: reference || null });
+      setAmount("");
+      setReference("");
+      await fetchSale();
+    } catch {
+      setPayError("Could not record the payment.");
+    } finally {
+      setSavingPay(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!window.confirm("Delete this sale? Stock will be returned and the customer balance updated.")) return;
+    try {
+      await api.delete(`/sales/${saleId}/`);
+      navigate("/sales");
+    } catch {
+      window.alert("Could not delete the sale.");
+    }
+  };
+
+  if (loading) return <div className="page-container"><p style={{ color: "var(--ink-600)" }}>Loading…</p></div>;
+  if (!sale) return <div className="page-container"><div className="surface empty-state"><strong>Sale not found.</strong></div></div>;
+
+  return (
+    <div className="page-container">
+      <PageHeader
+        eyebrow="Invoice"
+        title={sale.invoice_number}
+        description={`${sale.customer_name} · ${statusLabel(sale.payment_status)}`}
+        action={
+          <div className="page-actions no-print">
+            <button className="button button--ghost" onClick={() => window.print()}>
+              <Printer size={16} /> Print / PDF
+            </button>
+            {userRole.role === "admin" && (
+              <button className="button button--danger" onClick={handleDelete}>Delete</button>
+            )}
+          </div>
+        }
+      />
+
+      {/* Printable branded invoice */}
+      <section className="surface invoice-sheet">
+        <header className="invoice-head">
+          <div>
+            <h2 className="invoice-brand">Akinfolu Foods</h2>
+            <p className="invoice-brand__sub">Food wholesale &amp; distribution · Lagos</p>
+          </div>
+          <div className="invoice-meta">
+            <div><span>Invoice</span><strong>{sale.invoice_number}</strong></div>
+            <div><span>Date</span><strong>{sale.date}</strong></div>
+            {sale.salesperson && <div><span>Salesperson</span><strong>{sale.salesperson}</strong></div>}
+          </div>
+        </header>
+
+        <div className="invoice-billto">
+          <span className="customer-stat__label">Bill to</span>
+          <strong>{sale.customer_name}</strong>
+          <span style={{ color: "var(--ink-600)", textTransform: "capitalize" }}>{sale.customer_type} customer</span>
+        </div>
+
+        <table className="glass-table invoice-table">
+          <thead>
+            <tr>
+              <th>Item</th>
+              <th style={{ textAlign: "right" }}>Qty</th>
+              <th style={{ textAlign: "right" }}>Unit price</th>
+              <th style={{ textAlign: "right" }}>Amount</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sale.items.map((item) => (
+              <tr key={item.id}>
+                <td>{item.variant_label}</td>
+                <td style={{ textAlign: "right" }}>{item.quantity}</td>
+                <td style={{ textAlign: "right" }}>{formatNaira(item.unit_price)}</td>
+                <td style={{ textAlign: "right" }}>{formatNaira(item.line_total ?? Number(item.unit_price) * item.quantity)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+
+        <dl className="sale-totals invoice-totals">
+          <div><dt>Subtotal</dt><dd>{formatNaira(sale.subtotal)}</dd></div>
+          <div><dt>Discount</dt><dd>− {formatNaira(sale.discount)}</dd></div>
+          <div><dt>VAT ({sale.vat_rate}%)</dt><dd>{formatNaira(sale.vat_amount)}</dd></div>
+          <div className="sale-totals__grand"><dt>Total</dt><dd>{formatNaira(sale.total)}</dd></div>
+          <div><dt>Paid</dt><dd>{formatNaira(sale.amount_paid)}</dd></div>
+          <div className="sale-totals__grand"><dt>Balance due</dt><dd>{formatNaira(sale.balance)}</dd></div>
+        </dl>
+
+        {sale.notes && <p className="invoice-notes">{sale.notes}</p>}
+        <p className="invoice-foot">Thank you for your business.</p>
+      </section>
+
+      {/* Payments (not printed) */}
+      <section className="surface form-card no-print" style={{ marginTop: "18px" }}>
+        <h3 style={{ marginTop: 0, color: "var(--leaf-950)" }}>Payments</h3>
+
+        {sale.payments.length > 0 ? (
+          <table className="glass-table" style={{ marginBottom: "18px" }}>
+            <thead>
+              <tr><th>Date</th><th>Method</th><th>Reference</th><th style={{ textAlign: "right" }}>Amount</th></tr>
+            </thead>
+            <tbody>
+              {sale.payments.map((p) => (
+                <tr key={p.id}>
+                  <td>{p.date}</td>
+                  <td>{p.method_display}</td>
+                  <td>{p.reference || "—"}</td>
+                  <td style={{ textAlign: "right" }}>{formatNaira(p.amount)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        ) : (
+          <p style={{ color: "var(--ink-600)" }}>No payments recorded yet.</p>
+        )}
+
+        {Number(sale.balance) > 0 && (
+          <form onSubmit={handleAddPayment}>
+            {payError && <div className="notice notice--error" role="alert">{payError}</div>}
+            <div className="form-grid sale-summary__inputs">
+              <label className="field">
+                <span>Amount (₦)</span>
+                <input type="number" min={0} step="0.01" value={amount} onChange={(e) => setAmount(e.target.value)} placeholder={String(sale.balance)} />
+              </label>
+              <label className="field">
+                <span>Method</span>
+                <select value={method} onChange={(e) => setMethod(e.target.value)}>
+                  {PAYMENT_METHODS.map((m) => <option key={m.value} value={m.value}>{m.label}</option>)}
+                </select>
+              </label>
+              <label className="field">
+                <span>Reference</span>
+                <input value={reference} onChange={(e) => setReference(e.target.value)} placeholder="Optional" />
+              </label>
+            </div>
+            <div className="form-actions">
+              <button className="button button--primary" type="submit" disabled={savingPay}>
+                {savingPay ? "Saving…" : "Record payment"}
+              </button>
+            </div>
+          </form>
+        )}
+      </section>
+    </div>
+  );
+};
+
+export default SaleDetail;

--- a/src/pages/sales/salesTypes.ts
+++ b/src/pages/sales/salesTypes.ts
@@ -1,0 +1,52 @@
+export interface SaleItem {
+  id?: number;
+  variant: number;
+  variant_label?: string;
+  quantity: number;
+  unit_price: string;
+  line_total?: string;
+}
+
+export interface Payment {
+  id: number;
+  sale: number;
+  amount: string;
+  method: string;
+  method_display: string;
+  reference: string | null;
+  date: string;
+}
+
+export interface Sale {
+  id: number;
+  invoice_number: string;
+  customer: number;
+  customer_name: string;
+  customer_type: string;
+  salesperson: string | null;
+  date: string;
+  discount: string;
+  vat_rate: string;
+  subtotal: string;
+  vat_amount: string;
+  total: string;
+  amount_paid: string;
+  balance: string;
+  payment_status: "pending" | "partial" | "paid";
+  notes: string | null;
+  items: SaleItem[];
+  payments: Payment[];
+  created_at: string;
+}
+
+export const PAYMENT_METHODS = [
+  { value: "cash", label: "Cash" },
+  { value: "transfer", label: "Bank Transfer" },
+  { value: "pos", label: "POS" },
+];
+
+export const formatNaira = (value: string | number) =>
+  new Intl.NumberFormat("en-NG", { style: "currency", currency: "NGN" }).format(Number(value));
+
+export const statusLabel = (status: Sale["payment_status"]) =>
+  ({ pending: "Unpaid", partial: "Part-paid", paid: "Paid" }[status] ?? status);

--- a/src/pages/sales/view_sales/SalesList.tsx
+++ b/src/pages/sales/view_sales/SalesList.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import api from "../../../services/api";
+import GenericList from "../../../shared/list_page/GenericList";
+import { type Sale, formatNaira, statusLabel } from "../salesTypes";
+
+const statusColor: Record<string, string> = {
+  paid: "var(--leaf-650)",
+  partial: "var(--mango-500)",
+  pending: "var(--tomato-500)",
+};
+
+const SalesList = () => {
+  const navigate = useNavigate();
+  const [sales, setSales] = useState<Sale[]>([]);
+
+  useEffect(() => {
+    api
+      .get("/sales/?page_size=100")
+      .then((res) => setSales(res.data.results || res.data))
+      .catch((err) => console.error("Error fetching sales:", err));
+  }, []);
+
+  return (
+    <GenericList<Sale>
+      title="Sales"
+      eyebrow="Invoices"
+      description="Wholesale and retail sales, their totals and outstanding balances."
+      createPath="/sales/new"
+      createLabel="New sale"
+      items={sales}
+      itemKey={(item) => item.id}
+      enableSelection={false}
+      onItemClick={(id) => navigate(`/sales/${id}`)}
+      renderItem={(item) => (
+        <div className="inventory-list__content">
+          <div className="inventory-list__name">
+            <span>{item.invoice_number}</span>
+            <span className="customer-chip">{item.customer_name}</span>
+            <span style={{ color: statusColor[item.payment_status], fontWeight: 750, fontSize: ".78rem" }}>
+              {statusLabel(item.payment_status)}
+            </span>
+          </div>
+          <span className="inventory-list__open">
+            {formatNaira(item.total)}
+            {Number(item.balance) > 0 ? ` · ${formatNaira(item.balance)} due` : ""}
+          </span>
+        </div>
+      )}
+    />
+  );
+};
+
+export default SalesList;

--- a/src/pages/ware/ware_details/VariantModal.tsx
+++ b/src/pages/ware/ware_details/VariantModal.tsx
@@ -23,7 +23,8 @@ const VariantModal: React.FC<Props> = ({
 }) => {
   const [formData, setFormData] = useState({
     size: '',
-    price: '',
+    retail_price: '',
+    wholesale_price: '',
     is_available: true,
   });
 
@@ -31,13 +32,15 @@ const VariantModal: React.FC<Props> = ({
 
   useEffect(() => {
     if (variantToEdit) {
+      const v = variantToEdit as typeof variantToEdit & { retail_price?: string; wholesale_price?: string };
       setFormData({
         size: variantToEdit.size_detail.id.toString(),
-        price: variantToEdit.price,
+        retail_price: v.retail_price ?? variantToEdit.price ?? '',
+        wholesale_price: v.wholesale_price ?? '',
         is_available: variantToEdit.is_available,
       });
     } else {
-      setFormData({ size: '', price: '', is_available: true });
+      setFormData({ size: '', retail_price: '', wholesale_price: '', is_available: true });
     }
     setError('');
   }, [variantToEdit]);
@@ -57,7 +60,8 @@ const VariantModal: React.FC<Props> = ({
 
     const payload = {
       size: Number(formData.size),
-      price: formData.price,
+      retail_price: formData.retail_price || 0,
+      wholesale_price: formData.wholesale_price || 0,
       is_available: formData.is_available,
     };
 
@@ -110,11 +114,25 @@ const VariantModal: React.FC<Props> = ({
           </label>
 
           <label className="field">
-            <span>Price</span>
+            <span>Retail price (₦)</span>
             <input
               type="number"
-              name="price"
-              value={formData.price}
+              name="retail_price"
+              min={0}
+              step="0.01"
+              value={formData.retail_price}
+              onChange={handleChange}
+            />
+          </label>
+
+          <label className="field">
+            <span>Wholesale price (₦)</span>
+            <input
+              type="number"
+              name="wholesale_price"
+              min={0}
+              step="0.01"
+              value={formData.wholesale_price}
               onChange={handleChange}
             />
           </label>

--- a/src/pages/ware/ware_details/WareDetails.tsx
+++ b/src/pages/ware/ware_details/WareDetails.tsx
@@ -122,7 +122,8 @@ useEffect(() => {
                   {/* Left side: variant details */}
                   <div className="space-x-6 whitespace-nowrap">
                     <span><strong>Size:</strong> {variant.size_detail.size}{variant.size_detail.size_unit}</span>
-                    <span><strong>Price:</strong> {formatPrice(variant.price)}</span>
+                    <span><strong>Retail:</strong> {formatPrice((variant as typeof variant & { retail_price?: string }).retail_price ?? variant.price)}</span>
+                    <span><strong>Wholesale:</strong> {formatPrice((variant as typeof variant & { wholesale_price?: string }).wholesale_price ?? variant.price)}</span>
                     <span><strong>Available:</strong> {variant.is_available ? 'Yes' : 'No'}</span>
                   </div>
 


### PR DESCRIPTION
- New sale page: pick customer, add line items with auto wholesale/retail pricing (editable), live subtotal/discount/VAT/total, stock hints.
- Sales list: invoices with customer, total, balance and payment status.
- Sale detail: branded, print-ready invoice (Print/PDF via browser), payment recording (cash/transfer/POS) and payment history; admin delete returns stock. Print CSS hides chrome and shows only the invoice.
- Dual pricing in the variant editors (WareVariant form + VariantModal) and WareDetails now shows retail and wholesale prices.
- Sales nav entry and routes.


Claude-Session: https://claude.ai/code/session_01RWNgRTeigt7cf31qX9ibvE