### PR TITLE
feat(sales): reports page + customer purchase history & statements

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,9 +23,11 @@ import LowStockPage from './pages/low_stock/LowStockPage';
 import CustomerList from './pages/customer/view_customers/CustomerList';
 import CustomerForm from './pages/customer/CustomerForm';
 import CustomerDetail from './pages/customer/customer_details/CustomerDetail';
+import CustomerStatement from './pages/customer/customer_details/CustomerStatement';
 import SalesList from './pages/sales/view_sales/SalesList';
 import CreateSale from './pages/sales/create_sale/CreateSale';
 import SaleDetail from './pages/sales/sale_details/SaleDetail';
+import SalesReport from './pages/sales/reports/SalesReport';
 import ErrorBoundary from './pages/ErrorBoundary';
 import Login from './pages/login/login';
 import SignupPage from './pages/signup/SignupPage';
@@ -54,8 +56,10 @@ const App = () => {
             <Route path="/low-stock" element={<LowStockPage />} />
             <Route path="/customers" element={<CustomerList />} />
             <Route path="/customers/:customerId" element={<CustomerDetail />} />
+            <Route path="/customers/:customerId/statement" element={<CustomerStatement />} />
             <Route path="/sales" element={<SalesList />} />
             <Route path="/sales/new" element={<CreateSale />} />
+            <Route path="/sales/reports" element={<SalesReport />} />
             <Route path="/sales/:saleId" element={<SaleDetail />} />
             <Route element={<AdminRoute />}>
               <Route path="/add-ware" element={<ErrorBoundary><AddWare /></ErrorBoundary>} />

--- a/src/config/navigation.ts
+++ b/src/config/navigation.ts
@@ -7,6 +7,7 @@ export interface NavigationItem {
 export const primaryNavigation: NavigationItem[] = [
   { to: "/home", label: "Control desk", shortLabel: "Home" },
   { to: "/sales", label: "Sales", shortLabel: "Sales" },
+  { to: "/sales/reports", label: "Reports", shortLabel: "Reports" },
   { to: "/wares", label: "Products", shortLabel: "Products" },
   { to: "/brands", label: "Brands", shortLabel: "Brands" },
   { to: "/categories", label: "Categories", shortLabel: "Categories" },

--- a/src/features/layout/NavBar.tsx
+++ b/src/features/layout/NavBar.tsx
@@ -14,14 +14,16 @@ const Navbar = () => {
   // slide in from the left edge on initial load.
   const [ready, setReady] = useState(false);
 
+  // The active tab is the navigation entry whose path is the longest prefix
+  // of the current location, so /sales/reports lights Reports (not Sales).
+  const activeTo = primaryNavigation
+    .filter((link) => location.pathname === link.to || location.pathname.startsWith(`${link.to}/`))
+    .sort((a, b) => b.to.length - a.to.length)[0]?.to;
+
   const measurePill = useCallback(() => {
     const nav = navRef.current;
     if (!nav) return;
-    const active = primaryNavigation.find(
-      (link) =>
-        location.pathname === link.to || location.pathname.startsWith(`${link.to}/`)
-    );
-    const el = active ? linkRefs.current[active.to] : null;
+    const el = activeTo ? linkRefs.current[activeTo] : null;
     if (!el) {
       setPill((prev) => ({ ...prev, visible: false }));
       return;
@@ -29,7 +31,7 @@ const Navbar = () => {
     const navBox = nav.getBoundingClientRect();
     const box = el.getBoundingClientRect();
     setPill({ left: box.left - navBox.left + nav.scrollLeft, width: box.width, visible: true });
-  }, [location.pathname]);
+  }, [activeTo]);
 
   useLayoutEffect(() => {
     measurePill();
@@ -79,9 +81,7 @@ const Navbar = () => {
             ref={(el) => {
               linkRefs.current[link.to] = el;
             }}
-            className={({ isActive }) =>
-              `primary-nav__link${isActive ? " primary-nav__link--active" : ""}`
-            }
+            className={`primary-nav__link${link.to === activeTo ? " primary-nav__link--active" : ""}`}
           >
             {link.shortLabel}
           </NavLink>

--- a/src/index.css
+++ b/src/index.css
@@ -192,6 +192,14 @@ button, a { -webkit-tap-highlight-color: transparent; }
 .sale-totals__grand { padding-top: 8px; border-top: 1px solid var(--glass-border); font-size: 1.1rem; }
 .sale-totals__grand dt, .sale-totals__grand dd { color: var(--leaf-950); font-weight: 800; }
 
+/* Report bars */
+.report-bars { display: grid; gap: 10px; }
+.report-bar { display: grid; grid-template-columns: 110px 1fr auto; gap: 12px; align-items: center; }
+.report-bar__label { color: var(--ink-600); font-size: .8rem; font-weight: 700; }
+.report-bar__track { height: 12px; border-radius: 999px; background: rgba(255,255,255,.45); border: 1px solid var(--glass-border); overflow: hidden; }
+.report-bar__fill { display: block; height: 100%; border-radius: 999px; background: linear-gradient(90deg, var(--leaf-650), var(--mango-500)); }
+.report-bar__value { color: var(--leaf-950); font-weight: 750; font-size: .82rem; }
+
 /* Branded invoice sheet */
 .invoice-sheet { padding: clamp(22px, 4vw, 40px); }
 .invoice-head { display: flex; justify-content: space-between; gap: 24px; flex-wrap: wrap; padding-bottom: 20px; border-bottom: 2px solid var(--leaf-800); }

--- a/src/pages/customer/customer_details/CustomerDetail.tsx
+++ b/src/pages/customer/customer_details/CustomerDetail.tsx
@@ -4,19 +4,25 @@ import api from "../../../services/api";
 import PageHeader from "../../../components/ui/PageHeader";
 import { useUserRole } from "../../../hooks/useUserRole";
 import { type Customer, formatNaira } from "../customerTypes";
+import { type Sale, statusLabel } from "../../sales/salesTypes";
 
 const CustomerDetail = () => {
   const { customerId } = useParams<{ customerId: string }>();
   const navigate = useNavigate();
   const userRole = useUserRole();
   const [customer, setCustomer] = useState<Customer | null>(null);
+  const [sales, setSales] = useState<Sale[]>([]);
   const [loading, setLoading] = useState(true);
 
   const fetchCustomer = useCallback(async () => {
     try {
       setLoading(true);
-      const res = await api.get<Customer>(`/customers/${customerId}/`);
-      setCustomer(res.data);
+      const [c, s] = await Promise.all([
+        api.get<Customer>(`/customers/${customerId}/`),
+        api.get(`/sales/?customer=${customerId}&page_size=100`),
+      ]);
+      setCustomer(c.data);
+      setSales(s.data.results || s.data);
     } catch (error) {
       console.error("Failed to fetch customer:", error);
     } finally {
@@ -107,13 +113,39 @@ const CustomerDetail = () => {
           )}
         </section>
 
-        {/* Purchase history — filled in by the Sales & Invoicing module */}
+        {/* Purchase history */}
         <section className="surface form-card">
-          <h3 style={{ marginTop: 0, color: "var(--leaf-950)" }}>Purchase history</h3>
-          <div className="empty-state" style={{ padding: "40px 12px" }}>
-            <strong>Coming with Sales &amp; Invoicing</strong>
-            <p>Once invoices exist, this customer's orders, payments and statement will appear here.</p>
+          <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: "12px" }}>
+            <h3 style={{ margin: 0, color: "var(--leaf-950)" }}>Purchase history</h3>
+            {sales.length > 0 && (
+              <Link className="button button--ghost button--small" to={`/customers/${customer.id}/statement`}>Statement</Link>
+            )}
           </div>
+
+          {sales.length === 0 ? (
+            <div className="empty-state" style={{ padding: "40px 12px" }}>
+              <strong>No sales yet</strong>
+              <p>Invoices raised for this customer will appear here.</p>
+            </div>
+          ) : (
+            <table className="glass-table" style={{ marginTop: "12px" }}>
+              <thead>
+                <tr><th>Invoice</th><th>Date</th><th style={{ textAlign: "right" }}>Total</th><th style={{ textAlign: "right" }}>Balance</th></tr>
+              </thead>
+              <tbody>
+                {sales.map((s) => (
+                  <tr key={s.id} style={{ cursor: "pointer" }} onClick={() => navigate(`/sales/${s.id}`)}>
+                    <td>{s.invoice_number}</td>
+                    <td>{s.date}</td>
+                    <td style={{ textAlign: "right" }}>{formatNaira(s.total)}</td>
+                    <td style={{ textAlign: "right", color: Number(s.balance) > 0 ? "var(--tomato-500)" : "var(--leaf-650)" }}>
+                      {Number(s.balance) > 0 ? formatNaira(s.balance) : statusLabel(s.payment_status)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
         </section>
       </div>
     </div>

--- a/src/pages/customer/customer_details/CustomerStatement.tsx
+++ b/src/pages/customer/customer_details/CustomerStatement.tsx
@@ -1,0 +1,104 @@
+import { useCallback, useEffect, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import { Printer } from "lucide-react";
+import api from "../../../services/api";
+import PageHeader from "../../../components/ui/PageHeader";
+import { type Customer, formatNaira } from "../customerTypes";
+import { type Sale } from "../../sales/salesTypes";
+
+const CustomerStatement = () => {
+  const { customerId } = useParams<{ customerId: string }>();
+  const [customer, setCustomer] = useState<Customer | null>(null);
+  const [sales, setSales] = useState<Sale[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(async () => {
+    try {
+      setLoading(true);
+      const [c, s] = await Promise.all([
+        api.get<Customer>(`/customers/${customerId}/`),
+        api.get(`/sales/?customer=${customerId}&page_size=1000`),
+      ]);
+      setCustomer(c.data);
+      setSales(s.data.results || s.data);
+    } finally {
+      setLoading(false);
+    }
+  }, [customerId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  if (loading) return <div className="page-container"><p style={{ color: "var(--ink-600)" }}>Loading…</p></div>;
+  if (!customer) return <div className="page-container"><div className="surface empty-state"><strong>Customer not found.</strong></div></div>;
+
+  const ordered = [...sales].sort((a, b) => a.date.localeCompare(b.date));
+  const totalBilled = ordered.reduce((sum, s) => sum + Number(s.total), 0);
+  const totalPaid = ordered.reduce((sum, s) => sum + Number(s.amount_paid), 0);
+
+  return (
+    <div className="page-container">
+      <PageHeader
+        eyebrow="Customer directory"
+        title="Statement"
+        description={customer.name}
+        action={
+          <div className="page-actions no-print">
+            <Link className="button button--ghost" to={`/customers/${customer.id}`}>Back</Link>
+            <button className="button button--ghost" onClick={() => window.print()}><Printer size={16} /> Print / PDF</button>
+          </div>
+        }
+      />
+
+      <section className="surface invoice-sheet">
+        <header className="invoice-head">
+          <div>
+            <h2 className="invoice-brand">Akinfolu Foods</h2>
+            <p className="invoice-brand__sub">Customer statement</p>
+          </div>
+          <div className="invoice-meta">
+            <div><span>Customer</span><strong>{customer.name}</strong></div>
+            <div><span>Type</span><strong style={{ textTransform: "capitalize" }}>{customer.customer_type}</strong></div>
+            <div><span>As of</span><strong>{new Date().toISOString().slice(0, 10)}</strong></div>
+          </div>
+        </header>
+
+        {ordered.length === 0 ? (
+          <p style={{ marginTop: "20px", color: "var(--ink-600)" }}>No transactions yet.</p>
+        ) : (
+          <table className="glass-table invoice-table" style={{ marginTop: "20px" }}>
+            <thead>
+              <tr>
+                <th>Date</th><th>Invoice</th>
+                <th style={{ textAlign: "right" }}>Billed</th>
+                <th style={{ textAlign: "right" }}>Paid</th>
+                <th style={{ textAlign: "right" }}>Balance</th>
+              </tr>
+            </thead>
+            <tbody>
+              {ordered.map((s) => (
+                <tr key={s.id}>
+                  <td>{s.date}</td>
+                  <td>{s.invoice_number}</td>
+                  <td style={{ textAlign: "right" }}>{formatNaira(s.total)}</td>
+                  <td style={{ textAlign: "right" }}>{formatNaira(s.amount_paid)}</td>
+                  <td style={{ textAlign: "right" }}>{formatNaira(s.balance)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+
+        <dl className="sale-totals invoice-totals">
+          <div><dt>Total billed</dt><dd>{formatNaira(totalBilled)}</dd></div>
+          <div><dt>Total paid</dt><dd>{formatNaira(totalPaid)}</dd></div>
+          <div className="sale-totals__grand"><dt>Outstanding</dt><dd>{formatNaira(customer.outstanding_balance)}</dd></div>
+        </dl>
+        <p className="invoice-foot">Thank you for your business.</p>
+      </section>
+    </div>
+  );
+};
+
+export default CustomerStatement;

--- a/src/pages/sales/reports/SalesReport.tsx
+++ b/src/pages/sales/reports/SalesReport.tsx
@@ -1,0 +1,136 @@
+import { useCallback, useEffect, useState } from "react";
+import api from "../../../services/api";
+import PageHeader from "../../../components/ui/PageHeader";
+import { formatNaira } from "../salesTypes";
+
+interface Report {
+  totals: { sales: string; collected: string; outstanding: string; invoices: number };
+  by_period: { bucket: string; total: string; invoices: number }[];
+  top_products: { name: string; quantity: number; revenue: string }[];
+  by_customer_type: { customer_type: string; total: string; invoices: number }[];
+  by_salesperson: { salesperson: string; total: string; invoices: number }[];
+}
+
+const firstOfMonth = () => {
+  const d = new Date();
+  return new Date(d.getFullYear(), d.getMonth(), 1).toISOString().slice(0, 10);
+};
+const today = () => new Date().toISOString().slice(0, 10);
+
+const SalesReport = () => {
+  const [start, setStart] = useState(firstOfMonth());
+  const [end, setEnd] = useState(today());
+  const [period, setPeriod] = useState<"day" | "week" | "month">("day");
+  const [report, setReport] = useState<Report | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(() => {
+    setLoading(true);
+    api
+      .get(`/sales/report/?start=${start}&end=${end}&period=${period}`)
+      .then((res) => setReport(res.data))
+      .catch((err) => console.error("Report failed:", err))
+      .finally(() => setLoading(false));
+  }, [start, end, period]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const maxPeriod = report ? Math.max(...report.by_period.map((p) => Number(p.total)), 1) : 1;
+
+  return (
+    <div className="page-container">
+      <PageHeader
+        eyebrow="Invoices"
+        title="Sales reports"
+        description="Revenue, collections and top sellers over a date range."
+      />
+
+      <div className="surface form-card" style={{ marginBottom: "18px" }}>
+        <div className="form-grid sale-summary__inputs">
+          <label className="field"><span>From</span><input type="date" value={start} onChange={(e) => setStart(e.target.value)} /></label>
+          <label className="field"><span>To</span><input type="date" value={end} onChange={(e) => setEnd(e.target.value)} /></label>
+          <label className="field">
+            <span>Group by</span>
+            <select value={period} onChange={(e) => setPeriod(e.target.value as typeof period)}>
+              <option value="day">Day</option>
+              <option value="week">Week</option>
+              <option value="month">Month</option>
+            </select>
+          </label>
+        </div>
+      </div>
+
+      {loading || !report ? (
+        <p style={{ color: "var(--ink-600)" }}>Loading…</p>
+      ) : (
+        <>
+          <section className="customer-stats" style={{ gridTemplateColumns: "repeat(4, 1fr)" }}>
+            <div className="surface customer-stat"><span className="customer-stat__label">Total sales</span><strong className="customer-stat__value">{formatNaira(report.totals.sales)}</strong></div>
+            <div className="surface customer-stat"><span className="customer-stat__label">Collected</span><strong className="customer-stat__value" style={{ color: "var(--leaf-650)" }}>{formatNaira(report.totals.collected)}</strong></div>
+            <div className="surface customer-stat"><span className="customer-stat__label">Outstanding</span><strong className="customer-stat__value" style={{ color: Number(report.totals.outstanding) > 0 ? "var(--tomato-500)" : "var(--leaf-650)" }}>{formatNaira(report.totals.outstanding)}</strong></div>
+            <div className="surface customer-stat"><span className="customer-stat__label">Invoices</span><strong className="customer-stat__value">{report.totals.invoices}</strong></div>
+          </section>
+
+          <div className="customer-detail-grid">
+            <section className="surface form-card">
+              <h3 style={{ marginTop: 0, color: "var(--leaf-950)" }}>Sales over time</h3>
+              {report.by_period.length === 0 ? <p style={{ color: "var(--ink-600)" }}>No sales in range.</p> : (
+                <div className="report-bars">
+                  {report.by_period.map((row) => (
+                    <div className="report-bar" key={row.bucket}>
+                      <span className="report-bar__label">{row.bucket}</span>
+                      <span className="report-bar__track"><span className="report-bar__fill" style={{ width: `${(Number(row.total) / maxPeriod) * 100}%` }} /></span>
+                      <span className="report-bar__value">{formatNaira(row.total)}</span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </section>
+
+            <section className="surface form-card">
+              <h3 style={{ marginTop: 0, color: "var(--leaf-950)" }}>Top products</h3>
+              {report.top_products.length === 0 ? <p style={{ color: "var(--ink-600)" }}>No sales in range.</p> : (
+                <table className="glass-table">
+                  <thead><tr><th>Product</th><th style={{ textAlign: "right" }}>Qty</th><th style={{ textAlign: "right" }}>Revenue</th></tr></thead>
+                  <tbody>
+                    {report.top_products.map((p) => (
+                      <tr key={p.name}><td>{p.name}</td><td style={{ textAlign: "right" }}>{p.quantity}</td><td style={{ textAlign: "right" }}>{formatNaira(p.revenue)}</td></tr>
+                    ))}
+                  </tbody>
+                </table>
+              )}
+            </section>
+
+            <section className="surface form-card">
+              <h3 style={{ marginTop: 0, color: "var(--leaf-950)" }}>By customer type</h3>
+              <table className="glass-table">
+                <thead><tr><th>Type</th><th style={{ textAlign: "right" }}>Invoices</th><th style={{ textAlign: "right" }}>Total</th></tr></thead>
+                <tbody>
+                  {report.by_customer_type.map((r) => (
+                    <tr key={r.customer_type}><td style={{ textTransform: "capitalize" }}>{r.customer_type}</td><td style={{ textAlign: "right" }}>{r.invoices}</td><td style={{ textAlign: "right" }}>{formatNaira(r.total)}</td></tr>
+                  ))}
+                </tbody>
+              </table>
+            </section>
+
+            <section className="surface form-card">
+              <h3 style={{ marginTop: 0, color: "var(--leaf-950)" }}>By salesperson</h3>
+              <table className="glass-table">
+                <thead><tr><th>Salesperson</th><th style={{ textAlign: "right" }}>Invoices</th><th style={{ textAlign: "right" }}>Total</th></tr></thead>
+                <tbody>
+                  {report.by_salesperson.map((r) => (
+                    <tr key={r.salesperson}><td>{r.salesperson}</td><td style={{ textAlign: "right" }}>{r.invoices}</td><td style={{ textAlign: "right" }}>{formatNaira(r.total)}</td></tr>
+                  ))}
+                </tbody>
+              </table>
+            </section>
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default SalesReport;


### PR DESCRIPTION
- Sales reports page: date range + day/week/month grouping, summary cards (sales/collected/outstanding/invoices), a sales-over-time bar chart, top products, and revenue by customer type and salesperson.
- Customer detail now lists real purchase history (from /sales) and links to a printable customer statement (billed/paid/outstanding).
- Nav: add Reports. Fix active-tab detection to longest-prefix match so /sales/reports lights Reports, not Sales (and the pill aligns).


Claude-Session: https://claude.ai/code/session_01RWNgRTeigt7cf31qX9ibvE