### PR TITLE
feat(expenses): Expense & Spend Tracking UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,11 @@ import SalesList from './pages/sales/view_sales/SalesList';
 import CreateSale from './pages/sales/create_sale/CreateSale';
 import SaleDetail from './pages/sales/sale_details/SaleDetail';
 import SalesReport from './pages/sales/reports/SalesReport';
+import ExpenseList from './pages/expense/view_expenses/ExpenseList';
+import AddExpense from './pages/expense/add_expenses/AddExpense';
+import ExpenseCategoryList from './pages/expense/categories/ExpenseCategoryList';
+import AddExpenseCategory from './pages/expense/categories/AddExpenseCategory';
+import ExpenseReport from './pages/expense/reports/ExpenseReport';
 import ErrorBoundary from './pages/ErrorBoundary';
 import Login from './pages/login/login';
 import SignupPage from './pages/signup/SignupPage';
@@ -61,6 +66,9 @@ const App = () => {
             <Route path="/sales/new" element={<CreateSale />} />
             <Route path="/sales/reports" element={<SalesReport />} />
             <Route path="/sales/:saleId" element={<SaleDetail />} />
+            <Route path="/expenses" element={<ExpenseList />} />
+            <Route path="/expenses/report" element={<ExpenseReport />} />
+            <Route path="/expenses/categories" element={<ExpenseCategoryList />} />
             <Route element={<AdminRoute />}>
               <Route path="/add-ware" element={<ErrorBoundary><AddWare /></ErrorBoundary>} />
               <Route path="/brands/add" element={<AddBrand />} />
@@ -70,6 +78,8 @@ const App = () => {
               <Route path="/warehouses/add" element={<AddWarehouse />} />
               <Route path="/customers/add" element={<CustomerForm />} />
               <Route path="/customers/:customerId/edit" element={<CustomerForm />} />
+              <Route path="/expenses/add" element={<AddExpense />} />
+              <Route path="/expenses/categories/add" element={<AddExpenseCategory />} />
               <Route path="/wares/:wareId/variants/new" element={<WareVariantForm />} />
               <Route path="/wares/:wareId/variants/:variantId/edit" element={<WareVariantForm />} />
             </Route>

--- a/src/config/navigation.ts
+++ b/src/config/navigation.ts
@@ -8,6 +8,7 @@ export const primaryNavigation: NavigationItem[] = [
   { to: "/home", label: "Control desk", shortLabel: "Home" },
   { to: "/sales", label: "Sales", shortLabel: "Sales" },
   { to: "/sales/reports", label: "Reports", shortLabel: "Reports" },
+  { to: "/expenses", label: "Expenses", shortLabel: "Expenses" },
   { to: "/wares", label: "Products", shortLabel: "Products" },
   { to: "/brands", label: "Brands", shortLabel: "Brands" },
   { to: "/categories", label: "Categories", shortLabel: "Categories" },

--- a/src/pages/expense/add_expenses/AddExpense.tsx
+++ b/src/pages/expense/add_expenses/AddExpense.tsx
@@ -1,0 +1,136 @@
+import { useEffect, useState, type FormEvent } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import api from "../../../services/api";
+import PageHeader from "../../../components/ui/PageHeader";
+import { type ExpenseCategory, PAYMENT_METHODS } from "../expenseTypes";
+
+interface SupplierOption {
+  id: number;
+  name: string;
+}
+
+const AddExpense = () => {
+  const navigate = useNavigate();
+  const [categories, setCategories] = useState<ExpenseCategory[]>([]);
+  const [suppliers, setSuppliers] = useState<SupplierOption[]>([]);
+  const [form, setForm] = useState({
+    category: "",
+    supplier: "",
+    description: "",
+    amount: "",
+    payment_method: "cash",
+    reference: "",
+    date: new Date().toISOString().slice(0, 10),
+  });
+  const [receipt, setReceipt] = useState<File | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    api.get("/expense-categories/").then((res) => setCategories(res.data.results || res.data));
+    api.get("/suppliers/?page_size=1000").then((res) => setSuppliers(res.data.results || res.data));
+  }, []);
+
+  const set = (key: string, value: string) => setForm((prev) => ({ ...prev, [key]: value }));
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    setError(null);
+    if (!form.category) return setError("Choose a category.");
+    if (!form.amount || Number(form.amount) <= 0) return setError("Enter a valid amount.");
+
+    const data = new FormData();
+    data.append("category", form.category);
+    if (form.supplier) data.append("supplier", form.supplier);
+    data.append("description", form.description);
+    data.append("amount", form.amount);
+    data.append("payment_method", form.payment_method);
+    if (form.reference) data.append("reference", form.reference);
+    data.append("date", form.date);
+    if (receipt) data.append("receipt", receipt);
+
+    setSaving(true);
+    try {
+      await api.post("/expenses/", data);
+      navigate("/expenses");
+    } catch {
+      setError("Could not save the expense. Check the details and try again.");
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="page-container page-container--narrow">
+      <PageHeader eyebrow="Spend tracking" title="Add expense" description="Record a cost, attach a receipt, and tag it to a category." />
+
+      {categories.length === 0 ? (
+        <div className="surface form-card">
+          <div className="notice notice--error">You need an expense category first.</div>
+          <Link className="button button--primary" to="/expenses/categories/add">Create a category</Link>
+        </div>
+      ) : (
+        <form className="surface form-card" onSubmit={handleSubmit}>
+          {error && <div className="notice notice--error" role="alert">{error}</div>}
+          <div className="form-grid">
+            <label className="field">
+              <span>Category</span>
+              <select value={form.category} onChange={(e) => set("category", e.target.value)} required>
+                <option value="">Select category</option>
+                {categories.map((c) => <option key={c.id} value={c.id}>{c.name}</option>)}
+              </select>
+            </label>
+
+            <label className="field">
+              <span>Description</span>
+              <input value={form.description} onChange={(e) => set("description", e.target.value)} required placeholder="e.g. Diesel for delivery van" />
+            </label>
+
+            <label className="field">
+              <span>Amount (₦)</span>
+              <input type="number" min="0" step="0.01" value={form.amount} onChange={(e) => set("amount", e.target.value)} required />
+            </label>
+
+            <label className="field">
+              <span>Payment method</span>
+              <select value={form.payment_method} onChange={(e) => set("payment_method", e.target.value)}>
+                {PAYMENT_METHODS.map((m) => <option key={m.value} value={m.value}>{m.label}</option>)}
+              </select>
+            </label>
+
+            <label className="field">
+              <span>Supplier (optional)</span>
+              <select value={form.supplier} onChange={(e) => set("supplier", e.target.value)}>
+                <option value="">None</option>
+                {suppliers.map((s) => <option key={s.id} value={s.id}>{s.name}</option>)}
+              </select>
+            </label>
+
+            <label className="field">
+              <span>Reference (optional)</span>
+              <input value={form.reference} onChange={(e) => set("reference", e.target.value)} placeholder="Receipt no., txn id…" />
+            </label>
+
+            <label className="field">
+              <span>Date</span>
+              <input type="date" value={form.date} onChange={(e) => set("date", e.target.value)} required />
+            </label>
+
+            <label className="field">
+              <span>Receipt (optional)</span>
+              <input type="file" accept="image/*,application/pdf" onChange={(e) => setReceipt(e.target.files?.[0] ?? null)} />
+            </label>
+          </div>
+
+          <div className="form-actions">
+            <Link className="button button--ghost" to="/expenses">Cancel</Link>
+            <button className="button button--primary" type="submit" disabled={saving}>
+              {saving ? "Saving…" : "Save expense"}
+            </button>
+          </div>
+        </form>
+      )}
+    </div>
+  );
+};
+
+export default AddExpense;

--- a/src/pages/expense/categories/AddExpenseCategory.tsx
+++ b/src/pages/expense/categories/AddExpenseCategory.tsx
@@ -1,0 +1,19 @@
+import EntityCreatePage from "../../../components/ui/EntityCreatePage";
+
+const AddExpenseCategory = () => (
+  <EntityCreatePage
+    eyebrow="Spend tracking"
+    title="New expense category"
+    description="Group your costs and set an optional monthly budget to track spend against."
+    endpoint="/expense-categories/"
+    initialValues={{ name: "", monthly_budget: "0" }}
+    fields={[
+      { name: "name", label: "Category name", placeholder: "e.g. Logistics" },
+      { name: "monthly_budget", label: "Monthly budget (₦)", placeholder: "0", type: "number", required: false },
+    ]}
+    successMessage="Category saved and ready to use."
+    backTo="/expenses/categories"
+  />
+);
+
+export default AddExpenseCategory;

--- a/src/pages/expense/categories/ExpenseCategoryList.tsx
+++ b/src/pages/expense/categories/ExpenseCategoryList.tsx
@@ -1,0 +1,18 @@
+import ListPage from "../../../shared/list_page/ListPage";
+import { type ExpenseCategory } from "../expenseTypes";
+
+export default function ExpenseCategoryList() {
+  return (
+    <ListPage<ExpenseCategory>
+      title="Expense categories"
+      apiEndpoint="/expense-categories/"
+      itemKey={(item) => item.id}
+      itemNameSelector={(item) =>
+        `${item.name}${Number(item.monthly_budget) > 0 ? ` · budget ₦${Number(item.monthly_budget).toLocaleString()}` : ""}`
+      }
+      navigateTo={() => "/expenses/categories"}
+      createPath="/expenses/categories/add"
+      createLabel="Add category"
+    />
+  );
+}

--- a/src/pages/expense/expenseTypes.ts
+++ b/src/pages/expense/expenseTypes.ts
@@ -1,0 +1,31 @@
+export interface ExpenseCategory {
+  id: number;
+  name: string;
+  monthly_budget: string;
+}
+
+export interface Expense {
+  id: number;
+  category: number;
+  category_name: string;
+  supplier: number | null;
+  supplier_name: string | null;
+  description: string;
+  amount: string;
+  payment_method: string;
+  method_display: string;
+  reference: string | null;
+  receipt: string | null;
+  date: string;
+  created_at: string;
+}
+
+export const PAYMENT_METHODS = [
+  { value: "cash", label: "Cash" },
+  { value: "transfer", label: "Bank Transfer" },
+  { value: "pos", label: "POS" },
+  { value: "petty_cash", label: "Petty Cash" },
+];
+
+export const formatNaira = (value: string | number) =>
+  new Intl.NumberFormat("en-NG", { style: "currency", currency: "NGN" }).format(Number(value));

--- a/src/pages/expense/reports/ExpenseReport.tsx
+++ b/src/pages/expense/reports/ExpenseReport.tsx
@@ -1,0 +1,109 @@
+import { useCallback, useEffect, useState } from "react";
+import api from "../../../services/api";
+import PageHeader from "../../../components/ui/PageHeader";
+import { formatNaira } from "../expenseTypes";
+
+interface Report {
+  totals: { expenses: string; revenue: string; profit: string };
+  by_category: { category: string; budget: string; spent: string }[];
+  by_month: { bucket: string; total: string; count: number }[];
+}
+
+const firstOfYear = () => `${new Date().getFullYear()}-01-01`;
+const today = () => new Date().toISOString().slice(0, 10);
+
+const ExpenseReport = () => {
+  const [start, setStart] = useState(firstOfYear());
+  const [end, setEnd] = useState(today());
+  const [report, setReport] = useState<Report | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(() => {
+    setLoading(true);
+    api
+      .get(`/expenses/report/?start=${start}&end=${end}`)
+      .then((res) => setReport(res.data))
+      .catch((err) => console.error("Expense report failed:", err))
+      .finally(() => setLoading(false));
+  }, [start, end]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const profit = report ? Number(report.totals.profit) : 0;
+  const maxMonth = report ? Math.max(...report.by_month.map((m) => Number(m.total)), 1) : 1;
+
+  return (
+    <div className="page-container">
+      <PageHeader
+        eyebrow="Spend tracking"
+        title="Profit & loss"
+        description="Revenue against expenses, budget vs actual, and monthly spend."
+      />
+
+      <div className="surface form-card" style={{ marginBottom: "18px" }}>
+        <div className="form-grid sale-summary__inputs" style={{ gridTemplateColumns: "1fr 1fr" }}>
+          <label className="field"><span>From</span><input type="date" value={start} onChange={(e) => setStart(e.target.value)} /></label>
+          <label className="field"><span>To</span><input type="date" value={end} onChange={(e) => setEnd(e.target.value)} /></label>
+        </div>
+      </div>
+
+      {loading || !report ? (
+        <p style={{ color: "var(--ink-600)" }}>Loading…</p>
+      ) : (
+        <>
+          <section className="customer-stats">
+            <div className="surface customer-stat"><span className="customer-stat__label">Revenue</span><strong className="customer-stat__value" style={{ color: "var(--leaf-650)" }}>{formatNaira(report.totals.revenue)}</strong></div>
+            <div className="surface customer-stat"><span className="customer-stat__label">Expenses</span><strong className="customer-stat__value" style={{ color: "var(--tomato-500)" }}>{formatNaira(report.totals.expenses)}</strong></div>
+            <div className="surface customer-stat"><span className="customer-stat__label">{profit >= 0 ? "Profit" : "Loss"}</span><strong className="customer-stat__value" style={{ color: profit >= 0 ? "var(--leaf-650)" : "var(--tomato-500)" }}>{formatNaira(report.totals.profit)}</strong></div>
+          </section>
+
+          <div className="customer-detail-grid">
+            <section className="surface form-card">
+              <h3 style={{ marginTop: 0, color: "var(--leaf-950)" }}>Budget vs actual</h3>
+              {report.by_category.length === 0 ? <p style={{ color: "var(--ink-600)" }}>No categories yet.</p> : (
+                <div className="report-bars">
+                  {report.by_category.map((c) => {
+                    const budget = Number(c.budget);
+                    const spent = Number(c.spent);
+                    const pct = budget > 0 ? Math.min((spent / budget) * 100, 100) : spent > 0 ? 100 : 0;
+                    const over = budget > 0 && spent > budget;
+                    return (
+                      <div className="report-bar" key={c.category}>
+                        <span className="report-bar__label">{c.category}</span>
+                        <span className="report-bar__track">
+                          <span className="report-bar__fill" style={{ width: `${pct}%`, background: over ? "var(--tomato-500)" : undefined }} />
+                        </span>
+                        <span className="report-bar__value">
+                          {formatNaira(spent)}{budget > 0 ? ` / ${formatNaira(budget)}` : ""}
+                        </span>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </section>
+
+            <section className="surface form-card">
+              <h3 style={{ marginTop: 0, color: "var(--leaf-950)" }}>Monthly spend</h3>
+              {report.by_month.length === 0 ? <p style={{ color: "var(--ink-600)" }}>No expenses in range.</p> : (
+                <div className="report-bars">
+                  {report.by_month.map((m) => (
+                    <div className="report-bar" key={m.bucket}>
+                      <span className="report-bar__label">{m.bucket?.slice(0, 7)}</span>
+                      <span className="report-bar__track"><span className="report-bar__fill" style={{ width: `${(Number(m.total) / maxMonth) * 100}%` }} /></span>
+                      <span className="report-bar__value">{formatNaira(m.total)}</span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </section>
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default ExpenseReport;

--- a/src/pages/expense/view_expenses/ExpenseList.tsx
+++ b/src/pages/expense/view_expenses/ExpenseList.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { Plus, PieChart, Tags } from "lucide-react";
+import api from "../../../services/api";
+import PageHeader from "../../../components/ui/PageHeader";
+import { useUserRole } from "../../../hooks/useUserRole";
+import { type Expense, formatNaira } from "../expenseTypes";
+
+const ExpenseList = () => {
+  const userRole = useUserRole();
+  const [expenses, setExpenses] = useState<Expense[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    api
+      .get("/expenses/?page_size=200")
+      .then((res) => setExpenses(res.data.results || res.data))
+      .catch((err) => console.error("Error fetching expenses:", err))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const total = expenses.reduce((sum, e) => sum + Number(e.amount), 0);
+
+  return (
+    <div className="page-container">
+      <PageHeader
+        eyebrow="Spend tracking"
+        title="Expenses"
+        description="Every cost the business records, by category and payment method."
+        action={
+          <div className="page-actions">
+            <Link className="button button--ghost" to="/expenses/report"><PieChart size={16} /> P&amp;L report</Link>
+            <Link className="button button--ghost" to="/expenses/categories"><Tags size={16} /> Categories</Link>
+            {userRole.isAdmin && <Link className="button button--primary" to="/expenses/add"><Plus size={16} /> Add expense</Link>}
+          </div>
+        }
+      />
+
+      <section className="surface list-surface">
+        {loading ? (
+          <div className="empty-state"><strong>Loading…</strong></div>
+        ) : expenses.length === 0 ? (
+          <div className="empty-state"><strong>No expenses yet</strong><p>Record your first business expense.</p></div>
+        ) : (
+          <>
+            <div className="search-box" style={{ gridTemplateColumns: "1fr auto" }}>
+              <span style={{ fontWeight: 700, color: "var(--leaf-950)" }}>{expenses.length} expense{expenses.length === 1 ? "" : "s"}</span>
+              <small>Total {formatNaira(total)}</small>
+            </div>
+            <table className="glass-table">
+              <thead>
+                <tr>
+                  <th>Date</th><th>Description</th><th>Category</th><th>Method</th>
+                  <th style={{ textAlign: "right" }}>Amount</th><th>Receipt</th>
+                </tr>
+              </thead>
+              <tbody>
+                {expenses.map((e) => (
+                  <tr key={e.id}>
+                    <td>{e.date}</td>
+                    <td style={{ fontWeight: 650 }}>{e.description}</td>
+                    <td><span className="customer-chip">{e.category_name}</span></td>
+                    <td>{e.method_display}</td>
+                    <td style={{ textAlign: "right", fontWeight: 700 }}>{formatNaira(e.amount)}</td>
+                    <td>{e.receipt ? <a className="inventory-list__open" href={e.receipt} target="_blank" rel="noreferrer">View</a> : "—"}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </>
+        )}
+      </section>
+    </div>
+  );
+};
+
+export default ExpenseList;


### PR DESCRIPTION
- Expenses list with category chips, payment method, receipt links and a running total; header links to P&L report and categories.
- Add-expense form with category, optional supplier, payment method (incl. petty cash), reference, date and receipt file upload (multipart).
- Expense categories list + add (with monthly budget).
- Profit & loss page: revenue vs expenses cards, budget-vs-actual bars (over-budget in red), and a monthly spend chart.
- Expenses nav entry and routes (admin-gated create).


Claude-Session: https://claude.ai/code/session_01RWNgRTeigt7cf31qX9ibvE