### PR TITLE
style: restyle detail pages to the flat cream design

### DIFF
--- a/src/pages/expense/view_expenses/ExpenseList.tsx
+++ b/src/pages/expense/view_expenses/ExpenseList.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
-import { Plus, PieChart, Tags } from "lucide-react";
+import { Plus } from "lucide-react";
 import api from "../../../services/api";
 import PageHeader from "../../../components/ui/PageHeader";
 import { useUserRole } from "../../../hooks/useUserRole";
@@ -29,8 +29,6 @@ const ExpenseList = () => {
         description="Every cost the business records, by category and payment method."
         action={
           <div className="page-actions">
-            <Link className="button button--ghost" to="/expenses/report"><PieChart size={16} /> P&amp;L report</Link>
-            <Link className="button button--ghost" to="/expenses/categories"><Tags size={16} /> Categories</Link>
             {userRole.isAdmin && <Link className="button button--primary" to="/expenses/add"><Plus size={16} /> Add expense</Link>}
           </div>
         }

--- a/src/pages/low_stock/LowStockPage.tsx
+++ b/src/pages/low_stock/LowStockPage.tsx
@@ -46,27 +46,27 @@ export default function LowStockPage() {
       )}
 
       {variants.length > 0 && (
-        <div className="surface" style={{ overflowX: "auto" }}>
-          <table style={{ width: "100%", borderCollapse: "collapse" }}>
+        <div className="surface list-surface" style={{ overflowX: "auto" }}>
+          <table className="glass-table">
             <thead>
-              <tr style={{ textAlign: "left" }}>
-                <th style={{ padding: "0.5rem" }}>Product</th>
-                <th style={{ padding: "0.5rem" }}>Size</th>
-                <th style={{ padding: "0.5rem" }}>In stock</th>
-                <th style={{ padding: "0.5rem" }}>Reorder point</th>
-                <th style={{ padding: "0.5rem" }} />
+              <tr>
+                <th>Product</th>
+                <th>Size</th>
+                <th style={{ textAlign: "right" }}>In stock</th>
+                <th style={{ textAlign: "right" }}>Reorder point</th>
+                <th />
               </tr>
             </thead>
             <tbody>
               {variants.map((v) => (
-                <tr key={v.id} style={{ borderTop: "1px solid #eee" }}>
-                  <td style={{ padding: "0.5rem" }}>{v.ware_name}</td>
-                  <td style={{ padding: "0.5rem" }}>
+                <tr key={v.id}>
+                  <td style={{ fontWeight: 700, color: "var(--ink-900)" }}>{v.ware_name}</td>
+                  <td>
                     {v.size_detail?.size} {v.size_detail?.size_unit ?? ""}
                   </td>
-                  <td style={{ padding: "0.5rem", color: "#b91c1c", fontWeight: 600 }}>{v.stock}</td>
-                  <td style={{ padding: "0.5rem" }}>{v.reorder_point}</td>
-                  <td style={{ padding: "0.5rem" }}>
+                  <td style={{ textAlign: "right", color: "var(--danger)", fontWeight: 700 }}>{v.stock}</td>
+                  <td style={{ textAlign: "right" }}>{v.reorder_point}</td>
+                  <td style={{ textAlign: "right" }}>
                     <Link className="inventory-list__open" to={`/wares/${v.ware}`}>
                       View product →
                     </Link>

--- a/src/pages/ware/ware_details/WareDetails.tsx
+++ b/src/pages/ware/ware_details/WareDetails.tsx
@@ -66,155 +66,155 @@ useEffect(() => {
 
   return (
     <div className="page-container">
-      <h2 className="page-header" style={{ marginBottom: '20px' }}>
-        <span style={{ color: 'var(--leaf-950)', fontSize: 'clamp(2rem, 4vw, 3rem)', fontWeight: 800, letterSpacing: '-.04em' }}>{ware.name}</span>
-      </h2>
-
-      <div className="surface form-card">
-        {/* Ware Info */}
-        <p><strong>Brand:</strong> {ware.brand_detail.name}</p>
-        <p><strong>Category:</strong> {ware.category_detail.name}</p>
-        <p className="mb-4"><strong>Description:</strong> {ware.description}</p>
-
-        <p className="mb-6">
-          <strong>Sizes:</strong>{' '}
-          {ware.size_detail.length > 0 ? (
-            ware.size_detail.map((s, index) => (
-              <span key={index} className="role-badge" style={{ marginRight: '8px', marginBottom: '4px' }}>
-                {s.size}{s.size_unit}
-              </span>
-            ))
-          ) : (
-            <span className="text-sm italic" style={{ color: 'var(--ink-600)' }}>Not updated yet.</span>
-          )}
-        </p>
-
-        {/* Add Variant Button */}
-        <div className="flex flex-wrap gap-4 mb-6">
-          {userRole.role === 'admin' && (
-          <button
-            onClick={() => {
-              setVariantToEdit(null);
-              setShowVariantModal(true);
-            }}
-            className="button button--primary"
-          >
-            Add Product Type
-          </button>
-          )}
-        </div>
-
-        {/* Variants */}
+      <div className="page-header">
         <div>
-          <h3 className="text-xl font-semibold mb-4" style={{ color: 'var(--leaf-950)' }}>Product types</h3>
+          <p className="eyebrow">Inventory · Product</p>
+          <h1>{ware.name}</h1>
+          {ware.description && <p className="page-header__description">{ware.description}</p>}
+        </div>
+        {userRole.role === 'admin' && (
+          <div className="page-actions page-header__action">
+            <button
+              className="button button--primary"
+              onClick={() => {
+                setVariantToEdit(null);
+                setShowVariantModal(true);
+              }}
+            >
+              Add product type
+            </button>
+          </div>
+        )}
+      </div>
 
-          {ware.variants.length === 0 ? (
-            <p className="italic" style={{ color: 'var(--ink-600)' }}>Not updated yet.</p>
-          ) : (
-            ware.variants.map((variant) => (
-              <div
-                key={variant.id}
-                className="glass-panel p-4 mb-4"
-                style={{ borderRadius: '16px' }}
-              >
-                {/* Flex container for variant info and buttons */}
-                <div className="flex items-center justify-between mb-4" style={{ flexWrap: 'wrap', gap: '12px' }}>
-                  {/* Left side: variant details */}
-                  <div className="space-x-6 whitespace-nowrap">
-                    <span><strong>Size:</strong> {variant.size_detail.size}{variant.size_detail.size_unit}</span>
-                    <span><strong>Retail:</strong> {formatPrice((variant as typeof variant & { retail_price?: string }).retail_price ?? variant.price)}</span>
-                    <span><strong>Wholesale:</strong> {formatPrice((variant as typeof variant & { wholesale_price?: string }).wholesale_price ?? variant.price)}</span>
-                    <span><strong>Available:</strong> {variant.is_available ? 'Yes' : 'No'}</span>
-                  </div>
+      {/* Product profile */}
+      <section className="surface form-card" style={{ marginBottom: '18px' }}>
+        <dl className="customer-dl">
+          <div><dt>Brand</dt><dd>{ware.brand_detail.name}</dd></div>
+          <div><dt>Category</dt><dd>{ware.category_detail.name}</dd></div>
+          <div>
+            <dt>Sizes</dt>
+            <dd>
+              {ware.size_detail.length > 0 ? (
+                ware.size_detail.map((s, index) => (
+                  <span key={index} className="customer-chip" style={{ marginRight: '8px' }}>
+                    {s.size}{s.size_unit}
+                  </span>
+                ))
+              ) : (
+                <span style={{ color: 'var(--ink-600)' }}>Not updated yet.</span>
+              )}
+            </dd>
+          </div>
+        </dl>
+      </section>
 
-                  {/* Right side: buttons */}
-                  <div className="flex gap-3 flex-shrink-0" style={{ flexWrap: 'wrap' }}>
-                    {userRole.role === 'admin' && (
-                    <button
-                      onClick={() => {
-                        setVariantToEdit(variant);
-                        setShowVariantModal(true);
-                      }}
-                      className="button button--primary button--small"
-                    >
-                      Edit
-                    </button>
-                    )}
-
-                    {userRole.role === 'admin' && (
-                    <button
-                      onClick={() => handleDeleteVariant(variant.id)}
-                      className="button button--danger button--small"
-                    >
-                      Delete
-                    </button>
-
-                    )}
-
-                      {userRole.role === 'admin' && (
-                    <button
-                      onClick={() => {
-                        setSelectedVariantId(variant.id);
-                        setBatchToEdit(null);
-                        setShowBatchModal(true);
-                      }}
-                      className="button button--accent button--small"
-                    >
-                      Add Stock
-                    </button>
-                      )}
-                  </div>
+      {/* Variants */}
+      <h3 style={{ margin: '0 0 12px', color: 'var(--ink-900)' }}>Product types</h3>
+      {ware.variants.length === 0 ? (
+        <div className="surface empty-state">
+          <strong>No product types yet</strong>
+          <p>Add a size and price to start tracking stock for this product.</p>
+        </div>
+      ) : (
+        ware.variants.map((variant) => (
+          <section key={variant.id} className="surface" style={{ marginBottom: '16px', overflow: 'hidden' }}>
+            <div className="search-box" style={{ gridTemplateColumns: '1fr auto' }}>
+              <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: '16px' }}>
+                <strong style={{ color: 'var(--ink-900)', fontSize: '1rem' }}>
+                  {variant.size_detail.size}{variant.size_detail.size_unit}
+                </strong>
+                <span>Retail <strong style={{ color: 'var(--brand)' }}>{formatPrice((variant as typeof variant & { retail_price?: string }).retail_price ?? variant.price)}</strong></span>
+                <span>Wholesale <strong style={{ color: 'var(--brand)' }}>{formatPrice((variant as typeof variant & { wholesale_price?: string }).wholesale_price ?? variant.price)}</strong></span>
+                <span className="customer-chip">{variant.is_available ? 'In stock' : 'Out of stock'}</span>
+              </div>
+              {userRole.role === 'admin' && (
+                <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+                  <button
+                    onClick={() => {
+                      setSelectedVariantId(variant.id);
+                      setBatchToEdit(null);
+                      setShowBatchModal(true);
+                    }}
+                    className="button button--accent button--small"
+                  >
+                    Add stock
+                  </button>
+                  <button
+                    onClick={() => {
+                      setVariantToEdit(variant);
+                      setShowVariantModal(true);
+                    }}
+                    className="button button--ghost button--small"
+                  >
+                    Edit
+                  </button>
+                  <button
+                    onClick={() => handleDeleteVariant(variant.id)}
+                    className="button button--danger button--small"
+                  >
+                    Delete
+                  </button>
                 </div>
+              )}
+            </div>
 
-                {/* Batches */}
-                <div className="ml-4">
-                  <h4 className="text-md font-semibold mb-2" style={{ color: 'var(--leaf-800)' }}>Batches:</h4>
-                  {variant.batches && variant.batches.length > 0 ? (
-                    <ul className="list-disc ml-5 space-y-2" style={{ color: 'var(--ink-900)' }}>
-                      {variant.batches.map((batch) => (
-                        <li key={batch.id}>
-                          <p><strong>Batch Number:</strong> {batch.lot_number}</p>
-                          <p><strong>Quantity:</strong> {batch.quantity}</p>
-                          <p><strong>Manufacture Date:</strong> {formatDate(batch.manufacturing_date)}</p>
-                          <p><strong>Expiry Date:</strong> {formatDate(batch.expiry_date)}</p>
-                          <p><strong>Expired:</strong> {batch.is_expired ? 'Yes' : 'No'}</p>
-
-                          {/* Edit & Delete buttons for Batch */}
-                          <div className="flex gap-2 mt-2">
-                          {userRole.role === 'admin' && (
+            {variant.batches && variant.batches.length > 0 ? (
+              <table className="glass-table">
+                <thead>
+                  <tr>
+                    <th>Batch</th>
+                    <th style={{ textAlign: 'right' }}>Quantity</th>
+                    <th>Manufactured</th>
+                    <th>Expires</th>
+                    <th>Status</th>
+                    {userRole.role === 'admin' && <th />}
+                  </tr>
+                </thead>
+                <tbody>
+                  {variant.batches.map((batch) => (
+                    <tr key={batch.id}>
+                      <td style={{ fontWeight: 650 }}>{batch.lot_number || '—'}</td>
+                      <td style={{ textAlign: 'right' }}>{batch.quantity}</td>
+                      <td>{formatDate(batch.manufacturing_date)}</td>
+                      <td>{formatDate(batch.expiry_date)}</td>
+                      <td>
+                        <span style={{ color: batch.is_expired ? 'var(--danger)' : 'var(--brand)', fontWeight: 700, fontSize: '.82rem' }}>
+                          {batch.is_expired ? 'Expired' : 'Fresh'}
+                        </span>
+                      </td>
+                      {userRole.role === 'admin' && (
+                        <td style={{ textAlign: 'right' }}>
+                          <span style={{ display: 'inline-flex', gap: '8px' }}>
                             <button
                               onClick={() => {
                                 setBatchToEdit(batch);
                                 setSelectedVariantId(variant.id);
                                 setShowBatchModal(true);
                               }}
-                              className="button button--primary button--small"
+                              className="button button--ghost button--small"
                             >
-                              Edit Batch
+                              Edit
                             </button>
-                          )}
-
-                          {userRole.role === 'admin' && (
                             <button
                               onClick={() => handleDeleteBatch(batch.id)}
                               className="button button--danger button--small"
                             >
-                              Delete Batch
+                              Delete
                             </button>
-                          )}
-                          </div>
-                        </li>
-                      ))}
-                    </ul>
-                  ) : (
-                    <p className="text-sm italic" style={{ color: 'var(--ink-600)' }}>No batches added yet.</p>
-                  )}
-                </div>
-              </div>
-            ))
-          )}
-        </div>
-      </div>
+                          </span>
+                        </td>
+                      )}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            ) : (
+              <p style={{ margin: 0, padding: '14px 18px', color: 'var(--ink-600)' }}>No batches added yet.</p>
+            )}
+          </section>
+        ))
+      )}
 
       {/* Modals */}
       <VariantModal


### PR DESCRIPTION
Phase 2 of the redesign — align remaining old-era layouts:

- WareDetails: proper page header with actions, profile card (brand/ category/sizes), variants as clean sections with a header row and a real batches table (status column) instead of nested text lists.
- LowStockPage: replace the inline-styled table with the shared table styling.
- ExpenseList: drop header buttons now duplicated by the Reports sub-nav (categories stay reachable from Settings).


Claude-Session: https://claude.ai/code/session_01RWNgRTeigt7cf31qX9ibvE