### PR TITLE
fix(inventory): stop add-product dialog being clipped

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -98,8 +98,8 @@ button, a { -webkit-tap-highlight-color: transparent; }
 .notif-panel__item:hover { background: #f5f4ee; color: var(--ink-900); }
 .notif-panel__item svg { flex: 0 0 auto; margin-top: 2px; color: var(--amber); }
 
-/* Inline product add/edit popover */
-.product-pop { position: absolute; right: 14px; top: 60px; z-index: 30; width: min(340px, calc(100% - 28px)); padding: 16px; }
+/* Inline product add/edit popover — anchored under the search card's + button */
+.product-pop { position: absolute; right: 10px; top: calc(100% + 8px); z-index: 30; width: min(340px, calc(100% - 20px)); padding: 16px; }
 .product-pop__head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 12px; color: var(--ink-900); }
 .product-pop__close { border: 0; background: transparent; color: var(--ink-600); cursor: pointer; padding: 4px; border-radius: 8px; }
 .product-pop__close:hover { background: #f5f4ee; }

--- a/src/pages/product/ProductsPage.tsx
+++ b/src/pages/product/ProductsPage.tsx
@@ -106,8 +106,9 @@ const ProductsPage = () => {
 
   return (
     <div className="page-container page-container--narrow">
-      <div className="surface list-surface" style={{ position: "relative" }}>
-        <div className="search-box" style={{ gridTemplateColumns: canManage ? "auto 1fr auto" : "auto 1fr" }}>
+      {/* Search bar (its own card so the dialog can float free of the list's clip) */}
+      <div className="surface" style={{ position: "relative", marginBottom: "14px" }}>
+        <div className="search-box" style={{ borderBottom: "none", gridTemplateColumns: canManage ? "auto 1fr auto" : "auto 1fr" }}>
           <Search size={18} />
           <input
             type="search"
@@ -164,7 +165,10 @@ const ProductsPage = () => {
             </form>
           </div>
         )}
+      </div>
 
+      {/* Product list (its own card) */}
+      <div className="surface list-surface">
         {loading ? (
           <div className="empty-state"><strong>Loading…</strong></div>
         ) : visible.length === 0 ? (


### PR DESCRIPTION
The dialog lived inside the product card, which has overflow:hidden to round the list corners — so it was cut off and pushed out. Split the search bar into its own (non-clipping) card and anchor the dialog just below it, with the list in a separate card underneath.


Claude-Session: https://claude.ai/code/session_01RWNgRTeigt7cf31qX9ibvE