### PR TITLE
Add searchable customer picker in POS and password reveal on signup

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -125,6 +125,14 @@ button, a { -webkit-tap-highlight-color: transparent; }
 .topbar__search { flex: 1; max-width: 460px; display: flex; align-items: center; gap: 10px; padding: 9px 14px; border: 1px solid var(--line-strong); border-radius: 999px; background: var(--input-bg); color: var(--ink-600); }
 .topbar__search input { flex: 1; border: 0; outline: 0; background: transparent; color: var(--ink-900); min-width: 0; }
 .topbar__spacer { flex: 1; }
+
+/* Searchable dropdown (combobox), e.g. the POS customer picker */
+.combo { position: relative; }
+.combo__toggle { display: grid; place-items: center; border: 0; background: transparent; color: var(--ink-600); cursor: pointer; padding: 0; }
+.combo__menu { position: absolute; z-index: 30; top: calc(100% + 6px); left: 0; right: 0; max-height: 260px; overflow-y: auto; margin: 0; padding: 5px; list-style: none; background: var(--surface); border: 1px solid var(--line-strong); border-radius: 12px; box-shadow: 0 14px 34px rgba(0,0,0,.16); }
+.combo__item { display: block; width: 100%; text-align: left; padding: 10px 12px; border: 0; border-radius: 8px; background: transparent; color: var(--ink-900); cursor: pointer; font-size: .93rem; }
+.combo__item:hover, .combo__item--active { background: var(--hover); }
+.combo__empty { padding: 10px 12px; color: var(--ink-600); font-size: .88rem; }
 .topbar__bell-wrap { position: relative; }
 .topbar__bell { position: relative; border: 0; background: transparent; color: var(--ink-700); cursor: pointer; padding: 8px; border-radius: 10px; }
 .topbar__bell:hover { background: var(--hover); }

--- a/src/pages/login/login.module.css
+++ b/src/pages/login/login.module.css
@@ -40,12 +40,12 @@
 .authField input:focus { border-color: var(--brand); background: var(--surface); box-shadow: 0 0 0 3px rgba(31,74,49,.12); }
 /* Leave room for our eye toggle and hide the browser's native reveal/key
    button so the two icons don't overlap. */
-.authInputWrap input { padding-right: 44px; }
-.authField input::-ms-reveal,
-.authField input::-ms-clear { display: none; }
-.authField input::-webkit-credentials-auto-fill-button,
-.authField input::-webkit-strong-password-auto-fill-button,
-.authField input::-webkit-caps-lock-indicator { visibility: hidden; display: none !important; pointer-events: none; }
+.authInputWrap input { padding-right: 44px !important; }
+.authInputWrap input::-ms-reveal,
+.authInputWrap input::-ms-clear { display: none; }
+.authInputWrap input::-webkit-credentials-auto-fill-button,
+.authInputWrap input::-webkit-strong-password-auto-fill-button,
+.authInputWrap input::-webkit-caps-lock-indicator { visibility: hidden; display: none !important; pointer-events: none; }
 .passwordToggle { position: absolute; right: 8px; top: 50%; transform: translateY(-50%); border: 0; border-radius: 8px; padding: 8px; background: transparent; color: var(--ink-600); cursor: pointer; z-index: 2; }
 .submitButton { width: 100%; min-height: 46px; margin-top: 4px; border: 0; border-radius: 11px; color: #fff; background: var(--brand); font-weight: 800; cursor: pointer; box-shadow: 0 8px 20px rgba(31,74,49,.2); transition: background .15s, transform .1s; }
 .submitButton:hover { background: var(--brand-strong); }

--- a/src/pages/sales/pos/PointOfSale.tsx
+++ b/src/pages/sales/pos/PointOfSale.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
-import { Search, ShoppingCart, Plus, Minus, UserPlus, Package } from "lucide-react";
+import { Search, ShoppingCart, Plus, Minus, UserPlus, Package, ChevronDown } from "lucide-react";
 import api from "../../../services/api";
 import PageHeader from "../../../components/ui/PageHeader";
 import { formatNaira } from "../salesTypes";
@@ -22,15 +22,39 @@ const PointOfSale = () => {
   const [customers, setCustomers] = useState<CustomerOption[]>([]);
   const [products, setProducts] = useState<Product[]>([]);
   const [customerId, setCustomerId] = useState<number | "">("");
+  const [customerSearch, setCustomerSearch] = useState("");
+  const [customerOpen, setCustomerOpen] = useState(false);
   const [productQuery, setProductQuery] = useState("");
   const [cart, setCart] = useState<CartLine[]>([]);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const comboRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     api.get("/customers/?page_size=1000").then((r) => setCustomers(r.data.results || r.data));
     api.get("/products/").then((r) => setProducts(r.data.results || r.data));
   }, []);
+
+  useEffect(() => {
+    if (!customerOpen) return;
+    const close = (e: MouseEvent) => {
+      if (comboRef.current && !comboRef.current.contains(e.target as Node)) setCustomerOpen(false);
+    };
+    document.addEventListener("mousedown", close);
+    return () => document.removeEventListener("mousedown", close);
+  }, [customerOpen]);
+
+  const customerMatches = useMemo(() => {
+    const q = customerSearch.trim().toLowerCase();
+    const list = q ? customers.filter((c) => c.name.toLowerCase().includes(q)) : customers;
+    return [...list].sort((a, b) => a.name.localeCompare(b.name)).slice(0, 8);
+  }, [customers, customerSearch]);
+
+  const selectCustomer = (c: CustomerOption) => {
+    setCustomerId(c.id);
+    setCustomerSearch(c.name);
+    setCustomerOpen(false);
+  };
 
   const filtered = useMemo(() => {
     const q = productQuery.trim().toLowerCase();
@@ -87,10 +111,44 @@ const PointOfSale = () => {
             <div className="field" style={{ marginBottom: "14px" }}>
               <span>Customer</span>
               <div style={{ display: "flex", gap: "10px" }}>
-                <select value={customerId} onChange={(e) => setCustomerId(e.target.value ? Number(e.target.value) : "")} style={{ flex: 1 }}>
-                  <option value="">Search customer…</option>
-                  {customers.map((c) => <option key={c.id} value={c.id}>{c.name}</option>)}
-                </select>
+                <div className="combo" ref={comboRef} style={{ flex: 1 }}>
+                  <div className="topbar__search" style={{ maxWidth: "none" }}>
+                    <Search size={18} />
+                    <input
+                      value={customerSearch}
+                      onChange={(e) => { setCustomerSearch(e.target.value); setCustomerId(""); setCustomerOpen(true); }}
+                      onFocus={() => setCustomerOpen(true)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Escape") setCustomerOpen(false);
+                        if (e.key === "Enter" && customerMatches.length) { e.preventDefault(); selectCustomer(customerMatches[0]); }
+                      }}
+                      placeholder="Search customer…"
+                      aria-label="Search customer"
+                    />
+                    <button type="button" className="combo__toggle" onClick={() => setCustomerOpen((o) => !o)} aria-label="Show customers">
+                      <ChevronDown size={18} />
+                    </button>
+                  </div>
+                  {customerOpen && (
+                    <ul className="combo__menu">
+                      {customerMatches.length === 0 ? (
+                        <li className="combo__empty">No customers found.</li>
+                      ) : (
+                        customerMatches.map((c) => (
+                          <li key={c.id}>
+                            <button
+                              type="button"
+                              className={`combo__item${c.id === customerId ? " combo__item--active" : ""}`}
+                              onClick={() => selectCustomer(c)}
+                            >
+                              {c.name}
+                            </button>
+                          </li>
+                        ))
+                      )}
+                    </ul>
+                  )}
+                </div>
                 <Link className="button button--ghost" to="/customers/add"><UserPlus size={16} /> Add new</Link>
               </div>
             </div>

--- a/src/pages/signup/LabeledInput.tsx
+++ b/src/pages/signup/LabeledInput.tsx
@@ -1,3 +1,7 @@
+import { useState } from "react";
+import { Eye, EyeOff } from "lucide-react";
+import styles from "../login/login.module.css";
+
 interface LabeledInputProps {
   label: string;
   name: string;
@@ -10,18 +14,42 @@ interface LabeledInputProps {
 
 const LabeledInput: React.FC<LabeledInputProps> = ({
   label, name, type = "text", value, onChange, placeholder, required = false,
-}) => (
-  <div className="field">
-    <label htmlFor={name}>{label}</label>
+}) => {
+  const isPassword = type === "password";
+  const [show, setShow] = useState(false);
+  const inputType = isPassword ? (show ? "text" : "password") : type;
+
+  const input = (
     <input
       id={name}
       name={name}
-      type={type}
+      type={inputType}
       value={value}
       onChange={onChange}
       placeholder={placeholder}
       required={required}
     />
-  </div>
-);
+  );
+
+  return (
+    <div className="field">
+      <label htmlFor={name}>{label}</label>
+      {isPassword ? (
+        <div className={styles.authInputWrap}>
+          {input}
+          <button
+            type="button"
+            className={styles.passwordToggle}
+            onClick={() => setShow((s) => !s)}
+            aria-label={show ? "Hide password" : "Show password"}
+          >
+            {show ? <EyeOff size={19} /> : <Eye size={19} />}
+          </button>
+        </div>
+      ) : (
+        input
+      )}
+    </div>
+  );
+};
 export default LabeledInput;


### PR DESCRIPTION
- Replace the native customer <select> with a type-to-filter combobox (search field + chevron toggle + dropdown list) so cashiers can find a customer by typing instead of scrolling a long option list
- Add a show/hide password toggle to the signup password field, reusing the login styles and hiding the browser's native reveal button so the two icons don't overlap