### PR TITLE
Add walk-in sale shortcut to the POS

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -133,6 +133,8 @@ button, a { -webkit-tap-highlight-color: transparent; }
 .combo__item { display: block; width: 100%; text-align: left; padding: 10px 12px; border: 0; border-radius: 8px; background: transparent; color: var(--ink-900); cursor: pointer; font-size: .93rem; }
 .combo__item:hover, .combo__item--active { background: var(--hover); }
 .combo__empty { padding: 10px 12px; color: var(--ink-600); font-size: .88rem; }
+.pos-walkin { margin-top: 9px; padding: 0; border: 0; background: none; color: var(--brand); font-weight: 700; font-size: .82rem; cursor: pointer; text-align: left; }
+.pos-walkin:hover { text-decoration: underline; }
 .topbar__bell-wrap { position: relative; }
 .topbar__bell { position: relative; border: 0; background: transparent; color: var(--ink-700); cursor: pointer; padding: 8px; border-radius: 10px; }
 .topbar__bell:hover { background: var(--hover); }

--- a/src/pages/sales/pos/PointOfSale.tsx
+++ b/src/pages/sales/pos/PointOfSale.tsx
@@ -56,6 +56,16 @@ const PointOfSale = () => {
     setCustomerOpen(false);
   };
 
+  const selectWalkIn = async () => {
+    setError(null);
+    try {
+      const res = await api.get<CustomerOption>("/customers/walk-in/");
+      selectCustomer(res.data);
+    } catch {
+      setError("Could not start a walk-in sale. Try again.");
+    }
+  };
+
   const filtered = useMemo(() => {
     const q = productQuery.trim().toLowerCase();
     const list = q ? products.filter((p) => p.name.toLowerCase().includes(q)) : products;
@@ -151,6 +161,9 @@ const PointOfSale = () => {
                 </div>
                 <Link className="button button--ghost" to="/customers/add"><UserPlus size={16} /> Add new</Link>
               </div>
+              <button type="button" className="pos-walkin" onClick={selectWalkIn}>
+                No details — ring up a walk-in sale
+              </button>
             </div>
             <label className="field">
               <span>Products</span>


### PR DESCRIPTION
A 'ring up a walk-in sale' button under the customer picker selects the shared Walk-in Customer in one tap, so casual buyers can be served without entering any details.