### PR TITLE
Add post-sale print/home step with a printable receipt

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -307,6 +307,15 @@ button, a { -webkit-tap-highlight-color: transparent; }
 .confirm-card__actions { display: flex; justify-content: flex-end; gap: 10px; margin-top: 20px; }
 .confirm-card__actions .button { min-height: 44px; }
 
+/* POS receipt — hidden on screen, laid out only when printing. */
+.pos-receipt { display: none; }
+.pos-receipt__meta { margin: 2px 0; font-size: .82rem; }
+.pos-receipt__table { width: 100%; margin: 10px 0; border-collapse: collapse; }
+.pos-receipt__table td { padding: 3px 0; font-size: .85rem; vertical-align: top; }
+.pos-receipt__amt { text-align: right; white-space: nowrap; }
+.pos-receipt__total { display: flex; justify-content: space-between; margin: 8px 0 0; padding-top: 8px; border-top: 1px dashed #000; font-weight: 800; font-size: 1rem; }
+.pos-receipt__foot { margin-top: 14px; text-align: center; font-size: .8rem; }
+
 /* ---------------- Stat cards ---------------- */
 .stat-cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 16px; margin-bottom: 20px; }
 .stat-card { display: flex; align-items: center; justify-content: space-between; gap: 14px; padding: 18px 20px; }
@@ -501,6 +510,11 @@ button, a { -webkit-tap-highlight-color: transparent; }
   .invoice-sheet { border: 0; box-shadow: none; }
   .invoice-sheet, .invoice-sheet * { color: #111 !important; }
   .invoice-brand, .invoice-meta strong, .invoice-billto strong { color: #15568f !important; }
+
+  /* When printing from the POS, show only the receipt. */
+  .pos-page > *:not(.pos-receipt) { display: none !important; }
+  .pos-receipt { display: block !important; max-width: 320px; margin: 0 auto; color: #000 !important; }
+  .pos-receipt h2 { margin: 0 0 4px; text-align: center; font-size: 1.2rem; }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/pages/sales/pos/PointOfSale.tsx
+++ b/src/pages/sales/pos/PointOfSale.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
   Search, ShoppingCart, Plus, Minus, UserPlus,
-  ChevronDown, X, CheckCircle2,
+  ChevronDown, X, CheckCircle2, Printer,
 } from "lucide-react";
 import api from "../../../services/api";
 import PageHeader from "../../../components/ui/PageHeader";
@@ -24,6 +24,19 @@ const WALK_IN_NAME = "Walk-in Customer";
 const stockColor = (stock: number, reorder = 5) =>
   stock <= 0 ? "var(--danger)" : stock <= reorder ? "var(--amber)" : "var(--ok)";
 
+interface Receipt {
+  reference: string;
+  customerName: string;
+  date: string;
+  paymentMethod: string;
+  items: { name: string; quantity: number; price: string }[];
+  total: number;
+}
+
+const paymentLabel: Record<string, string> = {
+  cash: "Cash", transfer: "Transfer", pos: "POS", pay_later: "Pay later",
+};
+
 const PointOfSale = () => {
   const [customers, setCustomers] = useState<CachedCustomer[]>([]);
   const [products, setProducts] = useState<CachedProduct[]>([]);
@@ -44,6 +57,8 @@ const PointOfSale = () => {
   const [addingCustomer, setAddingCustomer] = useState(false);
   const [newCustomerName, setNewCustomerName] = useState("");
   const [confirmOpen, setConfirmOpen] = useState(false);
+  const [postSaleOpen, setPostSaleOpen] = useState(false);
+  const [lastSale, setLastSale] = useState<Receipt | null>(null);
   const comboRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -291,11 +306,25 @@ const PointOfSale = () => {
       });
       await offlineDb.meta.put("productUsage", nextUsage);
       await offlineDb.cart.clear();
+
+      // Snapshot for the printable receipt before the cart is cleared.
+      setLastSale({
+        reference: localReference,
+        customerName: customer.name,
+        date: new Intl.DateTimeFormat("en-NG", {
+          timeZone: "Africa/Lagos", dateStyle: "medium", timeStyle: "short",
+        }).format(new Date()),
+        paymentMethod,
+        items: cart.map((line) => ({ name: line.product.name, quantity: line.quantity, price: line.product.price })),
+        total,
+      });
+
       setProductUsage(nextUsage);
       setCart([]);
       setProductQuery("");
       setCartOpen(false);
       setSuccess(`${localReference} is saved safely on this device.`);
+      setPostSaleOpen(true);
       void syncPendingSales();
     } catch {
       setError("This device could not save the sale. Keep this screen open and try again.");
@@ -538,6 +567,46 @@ const PointOfSale = () => {
         onConfirm={() => void completeSale()}
         onCancel={() => setConfirmOpen(false)}
       />
+
+      {/* After a sale is recorded: print a receipt or return to a fresh sale. */}
+      {postSaleOpen && (
+        <div className="modal-overlay confirm-overlay" role="dialog" aria-modal="true" aria-label="Sale recorded">
+          <div className="confirm-card surface">
+            <h3 className="confirm-card__title">Sale recorded ✓</h3>
+            <div className="confirm-card__body">
+              {lastSale?.reference} — {formatNaira(lastSale?.total ?? 0)}. Print a receipt or start a new sale.
+            </div>
+            <div className="confirm-card__actions">
+              <button type="button" className="button button--ghost" onClick={() => setPostSaleOpen(false)}>Back to home</button>
+              <button type="button" className="button button--primary" onClick={() => window.print()}>
+                <Printer size={17} /> Print receipt
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {lastSale && (
+        <div className="pos-receipt" aria-hidden="true">
+          <h2>AkinFolu Foods</h2>
+          <p className="pos-receipt__meta">{lastSale.date}</p>
+          <p className="pos-receipt__meta">Ref: {lastSale.reference}</p>
+          <p className="pos-receipt__meta">Customer: {lastSale.customerName}</p>
+          <table className="pos-receipt__table">
+            <tbody>
+              {lastSale.items.map((item, index) => (
+                <tr key={index}>
+                  <td>{item.quantity} × {item.name}</td>
+                  <td className="pos-receipt__amt">{formatNaira(Number(item.price) * item.quantity)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <p className="pos-receipt__total"><span>Total</span><span>{formatNaira(lastSale.total)}</span></p>
+          <p className="pos-receipt__meta">Payment: {paymentLabel[lastSale.paymentMethod] ?? lastSale.paymentMethod}</p>
+          <p className="pos-receipt__foot">Thank you for your patronage.</p>
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
After a sale is confirmed and recorded, show a dialog offering to print a receipt or go back to the home screen. The receipt (store name, ref, date, customer, items, total, payment) is captured from the completed sale and prints on its own when chosen.